### PR TITLE
Remove column order requirement for header and data columns

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -147,7 +147,6 @@ export async function validateCsv(
     Papa.parse(input, {
       header: false,
       // chunkSize: 64 * 1024,
-      skipEmptyLines: "greedy",
       step: (row: Papa.ParseStepResult<string[]>, parser: Papa.Parser) => {
         try {
           handleParseStep(row, resolve, parser)

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -147,6 +147,7 @@ export async function validateCsv(
     Papa.parse(input, {
       header: false,
       // chunkSize: 64 * 1024,
+      skipEmptyLines: "greedy",
       step: (row: Papa.ParseStepResult<string[]>, parser: Papa.Parser) => {
         try {
           handleParseStep(row, resolve, parser)

--- a/src/versions/1.1/csv.ts
+++ b/src/versions/1.1/csv.ts
@@ -60,8 +60,6 @@ const ERRORS = {
   HEADER_COLUMN_BLANK: (column: string) => `"${column}" is blank`,
   HEADER_STATE_CODE: (column: string, stateCode: string) =>
     `Header column "${column}" includes an invalid state code "${stateCode}"`,
-  COLUMN_COUNT: (actual: number, expected: number) =>
-    `Received ${actual} columns, less than the required number ${expected}`,
   COLUMN_NAME: (actual: string, expected: string, format: string) =>
     `Column is "${actual}" and should be "${expected}" for ${format} format`,
   COLUMN_MISSING: (column: string, format: string) =>

--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -60,8 +60,6 @@ const ERRORS = {
   HEADER_COLUMN_BLANK: (column: string) => `"${column}" is blank`,
   HEADER_STATE_CODE: (column: string, stateCode: string) =>
     `Header column "${column}" includes an invalid state code "${stateCode}"`,
-  COLUMN_COUNT: (actual: number, expected: number) =>
-    `Received ${actual} columns, less than the required number ${expected}`,
   COLUMN_NAME: (actual: string, expected: string, format: string) =>
     `Column is "${actual}" and should be "${expected}" for ${format} format`,
   COLUMN_MISSING: (column: string, format: string) =>

--- a/test/csv.spec.ts
+++ b/test/csv.spec.ts
@@ -21,36 +21,46 @@ const VALID_HEADER_COLUMNS = HEADER_COLUMNS.map((c) =>
 )
 
 test("validateHeaderColumns", (t) => {
-  t.is(validateHeaderColumns([]).length, HEADER_COLUMNS.length)
-  t.deepEqual(validateHeaderColumns(VALID_HEADER_COLUMNS), [])
-  t.is(
-    validateHeaderColumns(VALID_HEADER_COLUMNS.slice(0, -1))[0].column,
-    VALID_HEADER_COLUMNS.length - 1
-  )
+  const emptyResult = validateHeaderColumns([])
+  t.is(emptyResult.errors.length, HEADER_COLUMNS.length)
+  t.is(emptyResult.columns.length, 0)
+  const basicResult = validateHeaderColumns(VALID_HEADER_COLUMNS)
+  t.is(basicResult.errors.length, 0)
+  t.deepEqual(basicResult.columns, VALID_HEADER_COLUMNS)
+  const reversedColumns = [...VALID_HEADER_COLUMNS].reverse()
+  const reverseResult = validateHeaderColumns(reversedColumns)
+  t.is(reverseResult.errors.length, 0)
+  t.deepEqual(reverseResult.columns, reversedColumns)
+  const extraColumns = [
+    "extra1",
+    ...VALID_HEADER_COLUMNS.slice(0, 2),
+    "extra2",
+    ...VALID_HEADER_COLUMNS.slice(2),
+  ]
+  const extraResult = validateHeaderColumns(extraColumns)
+  t.is(extraResult.errors.length, 0)
+  t.deepEqual(extraResult.columns, [
+    undefined,
+    ...VALID_HEADER_COLUMNS.slice(0, 2),
+    undefined,
+    ...VALID_HEADER_COLUMNS.slice(2),
+  ])
 })
 
 test("validateHeaderRow", (t) => {
-  t.is(validateHeaderRow([]).length, 1)
+  t.is(validateHeaderRow([], []).length, 1)
   t.is(
-    validateHeaderRow([
-      "name",
-      "2022-01-01",
-      "1.0.0",
-      "Woodlawn",
-      "Aid",
-      "001 | MD",
-    ]).length,
+    validateHeaderRow(
+      [],
+      ["name", "2022-01-01", "1.0.0", "Woodlawn", "Aid", "001 | MD"]
+    ).length,
     0
   )
   t.assert(
-    validateHeaderRow([
-      "",
-      "2022-01-01",
-      "1.0.0",
-      "Woodlawn",
-      "Aid",
-      "001 | MD",
-    ])[0].message.includes("blank")
+    validateHeaderRow(
+      [],
+      ["", "2022-01-01", "1.0.0", "Woodlawn", "Aid", "001 | MD"]
+    )[0].message.includes("blank")
   )
 })
 

--- a/test/csv.spec.ts
+++ b/test/csv.spec.ts
@@ -2,7 +2,6 @@ import test from "ava"
 import {
   validateHeaderColumns,
   validateHeaderRow,
-  validateWideColumns,
   validateColumns,
   validateTallFields,
   validateWideFields,
@@ -133,19 +132,68 @@ test("validateColumns tall", (t) => {
       ...getTallColumns([]),
       "test",
     ]).length,
-    9
+    1
   )
 })
 
-test("validateWideColumns", (t) => {
-  // Currently only checking for the order of additional_generic_notes
+test("validateColumns wide", (t) => {
+  const columns = [
+    ...BASE_COLUMNS,
+    ...MIN_MAX_COLUMNS,
+    "code | 1",
+    "code | 1 | type",
+    "standard_charge | Payer | Plan",
+    "standard_charge | Payer | Plan | percent",
+    "standard_charge | Payer | Plan | contracting_method",
+    "additional_payer_notes | Payer | Plan",
+    "additional_generic_notes",
+  ]
+  t.is(validateColumns(columns).length, 0)
+  // any order is fine
+  const reverseColumns = [...columns].reverse()
+  t.is(validateColumns(reverseColumns).length, 0)
+  // extra payer and plan are fine
   t.is(
-    validateWideColumns([
-      ...BASE_COLUMNS,
-      ...MIN_MAX_COLUMNS,
-      "standard_charge | Payer | Plan",
-      "additional_generic_notes",
-      "standard_charge | Payer | Plan | pct",
+    validateColumns([
+      ...columns,
+      "standard_charge | Payer | Plan 2",
+      "standard_charge | Payer | Plan 2 | percent",
+      "standard_charge | Payer | Plan 2 | contracting_method",
+      "additional_payer_notes | Payer | Plan 2",
+      "standard_charge | Another Payer | Plan",
+      "standard_charge | Another Payer | Plan | percent",
+      "standard_charge | Another Payer | Plan | contracting_method",
+      "additional_payer_notes | Another Payer | Plan",
+    ]).length,
+    0
+  )
+  // missing percent is an error
+  t.is(
+    validateColumns([
+      ...columns,
+      "standard_charge | Payer | Plan 2",
+      "standard_charge | Payer | Plan 2 | contracting_method",
+      "additional_payer_notes | Payer | Plan 2",
+    ]).length,
+    1
+  )
+  // missing contracting_method is an error
+  t.is(
+    validateColumns([
+      ...columns,
+      "standard_charge | Payer | Plan 2",
+      "standard_charge | Payer | Plan 2 | percent",
+      "additional_payer_notes | Payer | Plan 2",
+    ]).length,
+    1
+  )
+  // missing additional_payer_notes is an error
+  t.is(
+    validateColumns([
+      ...columns,
+      "standard_charge | Payer | Plan 2",
+      "standard_charge | Payer | Plan 2 | percent",
+      "standard_charge | Payer | Plan 2 | contracting_method",
     ]).length,
     1
   )

--- a/test/csv.spec.ts
+++ b/test/csv.spec.ts
@@ -48,19 +48,49 @@ test("validateHeaderColumns", (t) => {
 })
 
 test("validateHeaderRow", (t) => {
-  t.is(validateHeaderRow([], []).length, 1)
   t.is(
-    validateHeaderRow(
-      [],
-      ["name", "2022-01-01", "1.0.0", "Woodlawn", "Aid", "001 | MD"]
-    ).length,
+    validateHeaderRow(VALID_HEADER_COLUMNS, []).length,
+    VALID_HEADER_COLUMNS.length
+  )
+  t.is(
+    validateHeaderRow(VALID_HEADER_COLUMNS, [
+      "name",
+      "2022-01-01",
+      "1.0.0",
+      "Woodlawn",
+      "Aid",
+      "001 | MD",
+    ]).length,
+    0
+  )
+  const extraColumns = [
+    undefined,
+    ...VALID_HEADER_COLUMNS.slice(0, 2),
+    undefined,
+    ...VALID_HEADER_COLUMNS.slice(2),
+  ]
+  t.is(
+    validateHeaderRow(extraColumns, [
+      "",
+      "name",
+      "2022-01-01",
+      "",
+      "1.0.0",
+      "Woodlawn",
+      "Aid",
+      "001 | MD",
+    ]).length,
     0
   )
   t.assert(
-    validateHeaderRow(
-      [],
-      ["", "2022-01-01", "1.0.0", "Woodlawn", "Aid", "001 | MD"]
-    )[0].message.includes("blank")
+    validateHeaderRow(VALID_HEADER_COLUMNS, [
+      "",
+      "2022-01-01",
+      "1.0.0",
+      "Woodlawn",
+      "Aid",
+      "001 | MD",
+    ])[0].message.includes("blank")
   )
 })
 


### PR DESCRIPTION
## Problem

The existing implementation required header and data columns to be in a specific order. However, any order should be allowed.

## Solution

Instead of checking the columns in order against the list of required columns, the list of required columns has its entries removed as the column names are found within the provided data. If there are no required columns left at the end, then all required columns are present, and there are no errors. If any required columns are left, one error is produced for each missing required column.

## Result

The `HEADER_COLUMN_COUNT` error has been removed, since it is no longer being used. Rather than giving an error about the number of columns, each missing header column results in an error from `HEADER_COLUMN_MISSING`. A similar change is made for the data columns, removing `COLUMN_COUNT` and adding `COLUMN_MISSING`. A CSV with its header and data columns in an arbitrary order may be considered valid as long as the required columns are all present.

The change to this behavior is made for both 1.1 and 2.0 versions of the csv validation code.

## Test Plan

Tests for validateHeaderColumns and validateColumns are updated.
