### PR TITLE
Conditional checks 5-8 for CSV formats

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -464,7 +464,6 @@ function validateModifierRow(
     )
   )
 
-  // if ((row["drug_unit_of_measurement"] || "").trim()) {
   errors.push(
     ...validateOptionalFloatField(
       row,
@@ -482,7 +481,6 @@ function validateModifierRow(
       DRUG_UNITS
     )
   )
-  // }
 
   const chargeFields = [
     "standard_charge | gross",

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -551,7 +551,7 @@ test("validateRow tall conditionals", (t) => {
   t.is(invalidModifierErrors.length, 1)
   t.assert(
     invalidModifierErrors[0].message.includes(
-      "at least one of additional_generic_notes, standard_charge | negotiated_dollar, standard_charge | negotiated_percentage, standard_charge | negotiated_algorithm is required for tall format when a modifier is encoded without an item or service"
+      'at least one of "additional_generic_notes", "standard_charge | negotiated_dollar", "standard_charge | negotiated_percentage", "standard_charge | negotiated_algorithm" is required for tall format when a modifier is encoded without an item or service'
     )
   )
   const modifierWithNotesRow = {
@@ -639,6 +639,390 @@ test("validateRow tall conditionals", (t) => {
   t.assert(
     modifierWithWrongTypesErrors[2].message.includes(
       '"standard_charge | methodology" value "secret" is not one of the allowed values'
+    )
+  )
+})
+
+test("validateRow wide conditionals", (t) => {
+  const columns = [
+    ...BASE_COLUMNS,
+    "code | 1",
+    "code | 1 | type",
+    "code | 2",
+    "code | 2 | type",
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar",
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage",
+    "standard_charge | Payer One | Basic Plan | negotiated_algorithm",
+    "estimated_amount | Payer One | Basic Plan",
+    "standard_charge | Payer One | Basic Plan | methodology",
+    "additional_payer_notes | Payer One | Basic Plan",
+    "standard_charge | Payer Two | Special Plan | negotiated_dollar",
+    "standard_charge | Payer Two | Special Plan | negotiated_percentage",
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm",
+    "estimated_amount | Payer Two | Special Plan",
+    "standard_charge | Payer Two | Special Plan | methodology",
+    "additional_payer_notes | Payer Two | Special Plan",
+  ]
+  const basicRow = {
+    description: "basic description",
+    setting: "inpatient",
+    "code | 1": "12345",
+    "code | 1 | type": "DRG",
+    "code | 2": "",
+    "code | 2 | type": "",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
+    modifiers: "",
+    "standard_charge | gross": "100",
+    "standard_charge | discounted_cash": "200.50",
+    "standard_charge | min": "50",
+    "standard_charge | max": "500",
+    additional_generic_notes: "",
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "",
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "",
+    "standard_charge | Payer One | Basic Plan | negotiated_algorithm": "",
+    "estimated_amount | Payer One | Basic Plan": "",
+    "standard_charge | Payer One | Basic Plan | methodology": "",
+    "additional_payer_notes | Payer One | Basic Plan": "",
+    "standard_charge | Payer Two | Special Plan | negotiated_dollar": "",
+    "standard_charge | Payer Two | Special Plan | negotiated_percentage": "",
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm": "",
+    "estimated_amount | Payer Two | Special Plan": "",
+    "standard_charge | Payer Two | Special Plan | methodology": "",
+    "additional_payer_notes | Payer Two | Special Plan": "",
+  }
+  // If there is a "payer specific negotiated charge" encoded as a dollar amount,
+  // there must be a corresponding valid value encoded for the deidentified minimum and deidentified maximum negotiated charge data.
+  const dollarNoBoundsRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "300",
+    "standard_charge | min": "",
+    "standard_charge | max": "",
+  }
+  const dollarNoBoundsErrors = validateRow(dollarNoBoundsRow, 5, columns, true)
+  t.is(dollarNoBoundsErrors.length, 2)
+  t.assert(
+    dollarNoBoundsErrors[0].message.includes(
+      '"standard_charge | min" is required when a negotiated dollar amount is present'
+    )
+  )
+  t.assert(
+    dollarNoBoundsErrors[1].message.includes(
+      '"standard_charge | max" is required when a negotiated dollar amount is present'
+    )
+  )
+  const percentageNoBoundsRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "80",
+    "standard_charge | min": "",
+    "standard_charge | max": "",
+    "estimated_amount | Payer One | Basic Plan": "160",
+  }
+  const percentageNoBoundsErrors = validateRow(
+    percentageNoBoundsRow,
+    6,
+    columns,
+    true
+  )
+  t.is(percentageNoBoundsErrors.length, 0)
+  const algorithmNoBoundsRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_algorithm":
+      "standard logarithm table",
+    "standard_charge | min": "",
+    "standard_charge | max": "",
+    "estimated_amount | Payer One | Basic Plan": "160",
+  }
+  const algorithmNoBoundsErrors = validateRow(
+    algorithmNoBoundsRow,
+    7,
+    columns,
+    true
+  )
+  t.is(algorithmNoBoundsErrors.length, 0)
+
+  // If a "payer specific negotiated charge" can only be expressed as a percentage or algorithm,
+  // then a corresponding "Estimated Allowed Amount" must also be encoded. Required beginning 1/1/2025.
+  const enforceConditionals = new Date().getFullYear() >= 2025
+
+  const percentageWithEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "80",
+    "estimated_amount | Payer One | Basic Plan": "160",
+  }
+  const percentageWithEstimateErrors = validateRow(
+    percentageWithEstimateRow,
+    8,
+    columns,
+    true
+  )
+  t.is(percentageWithEstimateErrors.length, 0)
+  const percentageNoEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "80",
+  }
+  const percentageNoEstimateErrors = validateRow(
+    percentageNoEstimateRow,
+    9,
+    columns,
+    true
+  )
+  t.is(percentageNoEstimateErrors.length, 1)
+  t.assert(
+    percentageNoEstimateErrors[0].message.includes(
+      '"estimated_amount | Payer One | Basic Plan" is required to be a positive number when a negotiated percentage or algorithm is present, but negotiated dollar is not present'
+    )
+  )
+  t.is(percentageNoEstimateErrors[0].warning, !enforceConditionals)
+  const percentageWrongEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "80",
+    "estimated_amount | Payer Two | Special Plan": "55",
+  }
+  const percentageWrongEstimateErrors = validateRow(
+    percentageWrongEstimateRow,
+    10,
+    columns,
+    true
+  )
+  t.is(percentageWrongEstimateErrors.length, 1)
+  t.assert(
+    percentageWrongEstimateErrors[0].message.includes(
+      '"estimated_amount | Payer One | Basic Plan" is required to be a positive number when a negotiated percentage or algorithm is present, but negotiated dollar is not present'
+    )
+  )
+  t.is(percentageWrongEstimateErrors[0].warning, !enforceConditionals)
+  const algorithmWithEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm":
+      "useful function",
+    "estimated_amount | Payer Two | Special Plan": "55",
+  }
+  const algorithmWithEstimateErrors = validateRow(
+    algorithmWithEstimateRow,
+    11,
+    columns,
+    true
+  )
+  t.is(algorithmWithEstimateErrors.length, 0)
+  const algorithmNoEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm":
+      "useful function",
+  }
+  const algorithmNoEstimateErrors = validateRow(
+    algorithmNoEstimateRow,
+    12,
+    columns,
+    true
+  )
+  t.is(algorithmNoEstimateErrors.length, 1)
+  t.assert(
+    algorithmNoEstimateErrors[0].message.includes(
+      '"estimated_amount | Payer Two | Special Plan" is required to be a positive number when a negotiated percentage or algorithm is present, but negotiated dollar is not present'
+    )
+  )
+  t.is(algorithmNoEstimateErrors[0].warning, !enforceConditionals)
+  const algorithmWrongEstimateRow = {
+    ...basicRow,
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm":
+      "useful function",
+    "estimated_amount | Payer One | Basic Plan": "55",
+  }
+  const algorithmWrongEstimateErrors = validateRow(
+    algorithmWrongEstimateRow,
+    13,
+    columns,
+    true
+  )
+  t.is(algorithmWrongEstimateErrors.length, 1)
+  t.assert(
+    algorithmWrongEstimateErrors[0].message.includes(
+      '"estimated_amount | Payer Two | Special Plan" is required to be a positive number when a negotiated percentage or algorithm is present, but negotiated dollar is not present'
+    )
+  )
+  t.is(algorithmWrongEstimateErrors[0].warning, !enforceConditionals)
+
+  // If code type is NDC, then the corresponding drug unit of measure and
+  // drug type of measure data elements must be encoded. Required beginning 1/1/2025.
+  const ndcNoMeasurementRow = {
+    ...basicRow,
+    "code | 1 | type": "NDC",
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "300",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
+  }
+  const ndcNoMeasurementErrors = validateRow(
+    ndcNoMeasurementRow,
+    14,
+    columns,
+    true
+  )
+  t.is(ndcNoMeasurementErrors.length, 2)
+  t.assert(
+    ndcNoMeasurementErrors[0].message.includes(
+      '"drug_unit_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.assert(
+    ndcNoMeasurementErrors[1].message.includes(
+      '"drug_type_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.is(ndcNoMeasurementErrors[0].warning, !enforceConditionals)
+  t.is(ndcNoMeasurementErrors[1].warning, !enforceConditionals)
+  const ndcSecondNoMeasurementRow = {
+    ...basicRow,
+    "code | 2": "12345",
+    "code | 2 | type": "NDC",
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "300",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
+  }
+  const ndcSecondNoMeasurementErrors = validateRow(
+    ndcSecondNoMeasurementRow,
+    15,
+    columns,
+    true
+  )
+  t.is(ndcSecondNoMeasurementErrors.length, 2)
+  t.assert(
+    ndcSecondNoMeasurementErrors[0].message.includes(
+      '"drug_unit_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.assert(
+    ndcSecondNoMeasurementErrors[1].message.includes(
+      '"drug_type_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.is(ndcSecondNoMeasurementErrors[0].warning, !enforceConditionals)
+  t.is(ndcSecondNoMeasurementErrors[1].warning, !enforceConditionals)
+
+  // If a modifier is encoded without an item or service, then a description and one of the following
+  // is the minimum information required:
+  // additional_generic_notes, additional_payer_notes, standard_charge | negotiated_dollar,
+  // standard_charge | negotiated_percentage, or standard_charge | negotiated_algorithm
+  const invalidModifierRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+  }
+  const invalidModifierErrors = validateRow(
+    invalidModifierRow,
+    16,
+    columns,
+    true
+  )
+  t.is(invalidModifierErrors.length, 1)
+  t.assert(
+    invalidModifierErrors[0].message.includes(
+      'at least one of "additional_generic_notes", "standard_charge | Payer One | Basic Plan | negotiated_dollar", "standard_charge | Payer One | Basic Plan | negotiated_percentage", "standard_charge | Payer One | Basic Plan | negotiated_algorithm", "additional_payer_notes | Payer One | Basic Plan", "standard_charge | Payer Two | Special Plan | negotiated_dollar", "standard_charge | Payer Two | Special Plan | negotiated_percentage", "standard_charge | Payer Two | Special Plan | negotiated_algorithm", "additional_payer_notes | Payer Two | Special Plan" is required for wide format when a modifier is encoded without an item or service'
+    )
+  )
+  const modifierWithGenericNotesRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    additional_generic_notes: "useful notes about the modifier",
+  }
+  const modifierWithGenericNotesErrors = validateRow(
+    modifierWithGenericNotesRow,
+    17,
+    columns,
+    true
+  )
+  t.is(modifierWithGenericNotesErrors.length, 0)
+  const modifierWithPayerNotesRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    "additional_payer_notes | Payer One | Basic Plan":
+      "useful notes for this payer",
+  }
+  const modifierWithPayerNotesErrors = validateRow(
+    modifierWithPayerNotesRow,
+    18,
+    columns,
+    true
+  )
+  t.is(modifierWithPayerNotesErrors.length, 0)
+  const modifierWithDollarRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    "standard_charge | Payer Two | Special Plan | negotiated_dollar": "151",
+  }
+  const modifierWithDollarErrors = validateRow(
+    modifierWithDollarRow,
+    19,
+    columns,
+    true
+  )
+  t.is(modifierWithDollarErrors.length, 0)
+  const modifierWithPercentageRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "110",
+  }
+  const modifierWithPercentageErrors = validateRow(
+    modifierWithPercentageRow,
+    20,
+    columns,
+    true
+  )
+  t.is(modifierWithPercentageErrors.length, 0)
+  const modifierWithAlgorithmRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    "standard_charge | Payer Two | Special Plan | negotiated_algorithm":
+      "consult the table of numbers",
+  }
+  const modifierWithAlgorithmErrors = validateRow(
+    modifierWithAlgorithmRow,
+    21,
+    columns,
+    true
+  )
+  t.is(modifierWithAlgorithmErrors.length, 0)
+  // types are still enforced for a modifier row
+  const modifierWithWrongTypesRow = {
+    ...basicRow,
+    "code | 1": "",
+    "code | 1 | type": "",
+    modifiers: "50",
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "$100",
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "15%",
+    "standard_charge | Payer Two | Special Plan | methodology": "secret",
+  }
+  const modifierWithWrongTypesErrors = validateRow(
+    modifierWithWrongTypesRow,
+    22,
+    columns,
+    true
+  )
+  t.is(modifierWithWrongTypesErrors.length, 3)
+  t.assert(
+    modifierWithWrongTypesErrors[0].message.includes(
+      '"standard_charge | Payer One | Basic Plan | negotiated_dollar" value "$100" is not a valid positive number'
+    )
+  )
+  t.assert(
+    modifierWithWrongTypesErrors[1].message.includes(
+      '"standard_charge | Payer One | Basic Plan | negotiated_percentage" value "15%" is not a valid positive number'
+    )
+  )
+  t.assert(
+    modifierWithWrongTypesErrors[2].message.includes(
+      '"standard_charge | Payer Two | Special Plan | methodology" value "secret" is not one of the allowed values'
     )
   )
 })

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -348,8 +348,8 @@ test("validateRow tall conditionals", (t) => {
     "code | 1 | type": "DRG",
     "code | 2": "",
     "code | 2 | type": "",
-    drug_unit_of_measurement: "8.5",
-    drug_type_of_measurement: "ML",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
     modifiers: "",
     "standard_charge | gross": "100",
     "standard_charge | discounted_cash": "200.50",
@@ -477,4 +477,58 @@ test("validateRow tall conditionals", (t) => {
     )
   )
   t.is(algorithmNoEstimateErrors[0].warning, !enforceConditionals)
+
+  // If code type is NDC, then the corresponding drug unit of measure and
+  // drug type of measure data elements must be encoded. Required beginning 1/1/2025.
+  const ndcNoMeasurementRow = {
+    ...basicRow,
+    "code | 1 | type": "NDC",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
+  }
+  const ndcNoMeasurementErrors = validateRow(
+    ndcNoMeasurementRow,
+    12,
+    columns,
+    false
+  )
+  t.is(ndcNoMeasurementErrors.length, 2)
+  t.assert(
+    ndcNoMeasurementErrors[0].message.includes(
+      '"drug_unit_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.assert(
+    ndcNoMeasurementErrors[1].message.includes(
+      '"drug_type_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.is(ndcNoMeasurementErrors[0].warning, !enforceConditionals)
+  t.is(ndcNoMeasurementErrors[1].warning, !enforceConditionals)
+  const ndcSecondNoMeasurementRow = {
+    ...basicRow,
+    "code | 2": "12345",
+    "code | 2 | type": "NDC",
+    drug_unit_of_measurement: "",
+    drug_type_of_measurement: "",
+  }
+  const ndcSecondNoMeasurementErrors = validateRow(
+    ndcSecondNoMeasurementRow,
+    13,
+    columns,
+    false
+  )
+  t.is(ndcSecondNoMeasurementErrors.length, 2)
+  t.assert(
+    ndcSecondNoMeasurementErrors[0].message.includes(
+      '"drug_unit_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.assert(
+    ndcSecondNoMeasurementErrors[1].message.includes(
+      '"drug_type_of_measurement" is required when an NDC code is present'
+    )
+  )
+  t.is(ndcSecondNoMeasurementErrors[0].warning, !enforceConditionals)
+  t.is(ndcSecondNoMeasurementErrors[1].warning, !enforceConditionals)
 })


### PR DESCRIPTION
This PR adds conditional checks 5-8 from the CSV 2.0 format described in the [HPT repo](https://github.com/CMSgov/hospital-price-transparency). These checks apply to both the tall and wide CSV formats. These checks are:

- If there is a "payer specific negotiated charge" encoded as a dollar amount, there must be a corresponding valid value encoded for the deidentified minimum and deidentified maximum negotiated charge data.
- If a "payer specific negotiated charge" can only be expressed as a percentage or algorithm, then a corresponding "Estimated Allowed Amount" must also be encoded. Required beginning 1/1/2025.
- If code type is NDC, then the corresponding drug unit of measure and drug type of measure data element must be encoded. Required beginning 1/1/2025.
- If a modifier is encoded without an item or service, then a description and one of the following is the minimum information required: additional_payer_notes, standard_charge | negotiated_dollar, standard_charge | negotiated_percentage, or standard_charge | negotiated_algorithm.