### PR TITLE
Provide more specific message for invalid state code in header

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -62,8 +62,8 @@ const ERRORS = {
   HEADER_COLUMN_MISSING: (column: string) =>
     `Header column should be "${column}", but it is not present`,
   HEADER_COLUMN_BLANK: (column: string) => `"${column}" is blank`,
-  HEADER_STATE_CODE: (column: string, stateCode: string) =>
-    `Header column "${column}" includes an invalid state code "${stateCode}"`,
+  HEADER_STATE_CODE: (stateCode: string) =>
+    `${stateCode} is not an allowed value for state abbreviation. You must fill in the state or territory abbreviation even if there is no license number to encode. See the table found here for the list of valid values for state and territory abbreviations https://github.com/CMSgov/hospital-price-transparency/blob/master/documentation/CSV/state_codes.md`,
   DUPLICATE_HEADER_COLUMN: (column: string) =>
     `Column ${column} duplicated in header`,
   COLUMN_MISSING: (column: string, format: string) =>
@@ -131,7 +131,7 @@ export function validateHeaderColumns(columns: string[]): {
                 rowIndex,
                 index,
                 requiredColumn,
-                ERRORS.HEADER_STATE_CODE(column, splitColumn[1])
+                ERRORS.HEADER_STATE_CODE(splitColumn[1])
               )
             )
             return false
@@ -350,20 +350,6 @@ export function validateRow(
         DRUG_UNITS
       )
     )
-    // if (!DRUG_UNITS.includes(row["drug_type_of_measurement"] as DrugUnit)) {
-    //   errors.push(
-    //     csvErr(
-    //       index,
-    //       columns.indexOf("drug_type_of_measurement"),
-    //       "drug_type_of_measurement",
-    //       ERRORS.ALLOWED_VALUES(
-    //         "drug_type_of_measurement",
-    //         row["drug_type_of_measurement"],
-    //         DRUG_UNITS as unknown as string[]
-    //       )
-    //     )
-    //   )
-    // }
   }
 
   const chargeFields = [

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -51,9 +51,10 @@ test("validateHeaderColumns", (t) => {
   )
   const invalidStateErrors = validateHeaderColumns(invalidStateColumns)
   t.is(invalidStateErrors.errors.length, 2)
-  t.is(
-    invalidStateErrors.errors[0].message,
-    'Header column "license_number | ZZ" includes an invalid state code "ZZ"'
+  t.assert(
+    invalidStateErrors.errors[0].message.includes(
+      "ZZ is not an allowed value for state abbreviation"
+    )
   )
 })
 

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/versions/2.0/csv.js"
 
 const VALID_HEADER_COLUMNS = HEADER_COLUMNS.map((c) =>
-  c === "license_number | state" ? "license_number | MD" : c
+  c === "license_number | [state]" ? "license_number | MD" : c
 )
 
 test("validateHeaderColumns", (t) => {
@@ -46,6 +46,15 @@ test("validateHeaderColumns", (t) => {
     "Column hospital_location duplicated in header"
   )
   t.deepEqual(duplicateResult.columns, VALID_HEADER_COLUMNS)
+  const invalidStateColumns = HEADER_COLUMNS.map((c) =>
+    c === "license_number | [state]" ? "license_number | ZZ" : c
+  )
+  const invalidStateErrors = validateHeaderColumns(invalidStateColumns)
+  t.is(invalidStateErrors.errors.length, 2)
+  t.is(
+    invalidStateErrors.errors[0].message,
+    'Header column "license_number | ZZ" includes an invalid state code "ZZ"'
+  )
 })
 
 test("validateHeaderRow", (t) => {


### PR DESCRIPTION
When validating the header columns, assume that a column name that contains one pipe and matches "license_number" before the pipe is probably the license number column. This means that the part of the name after the pipe should be a valid state code. If not, show an error message indicating that the state code is not valid.