### PR TITLE
Allow warnings in header and columns

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -103,7 +103,7 @@ export async function validateCsv(
     } else if (index === 2) {
       dataColumns = cleanColumnNames(row)
       errors.push(...validator.validateColumns(dataColumns))
-      if (errors.length > 0) {
+      if (errors.some((err) => !err.warning)) {
         resolve({
           valid: false,
           errors: errors.map(csvErrorToValidationError).concat({


### PR DESCRIPTION
If errors occur during validation of the header and columns, parsing stops. Parsing continues as long as no errors occur, even if warnings occur.

Note that the current implementation does not have any associated tests. The currently implemented CSV validators do not have any way of creating a warning when validating the header and columns. Testing this will require finding and using a function mock package, which will require additional research.