### PR TITLE
Set warning flag in JSON for conditions applicable in 2025

### DIFF
--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -115,6 +115,22 @@ const STANDARD_CHARGE_DEFINITIONS = {
       },
     },
     required: ["description", "code_information", "standard_charges"],
+    if: {
+      properties: {
+        code_information: {
+          contains: {
+            properties: {
+              type: {
+                const: "NDC",
+              },
+            },
+          },
+        },
+      },
+    },
+    then: {
+      required: ["drug_information"],
+    },
   },
   payers_information: {
     type: "object",
@@ -132,18 +148,35 @@ const STANDARD_CHARGE_DEFINITIONS = {
       },
     },
     required: ["payer_name", "plan_name", "methodology"],
-
-    if: {
-      properties: {
-        methodology: {
-          const: "other",
+    allOf: [
+      {
+        if: {
+          properties: {
+            methodology: {
+              const: "other",
+            },
+          },
+          required: ["methodology"],
+        },
+        then: {
+          required: ["additional_payer_notes"],
         },
       },
-      required: ["methodology"],
-    },
-    then: {
-      required: ["additional_payer_notes"],
-    },
+      {
+        if: {
+          anyOf: [
+            { required: ["standard_charge_percentage"] },
+            { required: ["standard_charge_algorithm"] },
+          ],
+          not: {
+            required: ["standard_charge_dollar"],
+          },
+        },
+        then: {
+          required: ["estimated_amount"], // Required beginning 1/1/2025
+        },
+      },
+    ],
   },
 }
 
@@ -164,6 +197,23 @@ const STANDARD_CHARGE_PROPERTIES = {
     },
   },
   required: ["description", "code_information", "standard_charges"],
+
+  if: {
+    properties: {
+      code_information: {
+        contains: {
+          properties: {
+            type: {
+              const: "NDC",
+            },
+          },
+        },
+      },
+    },
+  },
+  then: {
+    required: ["drug_information"],
+  },
 }
 
 export const STANDARD_CHARGE_SCHEMA = {
@@ -324,27 +374,53 @@ export async function validateJson(
   let valid = true
   let hasCharges = false
   const errors: ValidationError[] = []
+  const enforce2025 = new Date().getFullYear() >= 2025
+  let warningCount = 0
+  let errorCount = 0
 
   return new Promise(async (resolve, reject) => {
     // TODO: currently this is still storing the full array of items in "parent", but we
     // would need to override some internals to get around that
     parser.onValue = ({ value, key, stack }) => {
-      if (stack.length > 2 || key === "standard_charge_information") return
+      if (stack.length > 2 || key === "standard_charge_information") {
+        return
+      }
       if (typeof key === "string") {
         metadata[key] = value
       } else {
         // is this where I need to put another check for the modifier information?
         hasCharges = true
         if (!validator.validate(STANDARD_CHARGE_SCHEMA, value)) {
-          valid = false
-          errors.push(
-            ...(validator.errors as ErrorObject[])
-              .map(errorObjectToValidationError)
-              .map((error) => ({
-                ...error,
-                path: error.path.replace(/\/0\//gi, `/${key}/`),
-              }))
-          )
+          let validationErrors = (validator.errors as ErrorObject[])
+            .map(
+              enforce2025
+                ? errorObjectToValidationError
+                : errorObjectToValidationErrorWithWarnings
+            )
+            .map((error) => ({
+              ...error,
+              path: error.path.replace(/\/0\//gi, `/${key}/`),
+            }))
+          // if warning list is already full, don't add the new warnings
+          if (
+            options.maxErrors != null &&
+            options.maxErrors > 0 &&
+            warningCount > options.maxErrors
+          ) {
+            validationErrors = validationErrors.filter(
+              (error) => error.warning !== true
+            )
+            errors.push(...validationErrors)
+            errorCount += validationErrors.length
+          } else {
+            errors.push(...validationErrors)
+            const additionalWarningCount = validationErrors.filter(
+              (err) => err.warning
+            ).length
+            warningCount += additionalWarningCount
+            errorCount += validationErrors.length - additionalWarningCount
+          }
+          valid = errorCount === 0
         }
         if (options.onValueCallback) {
           options.onValueCallback(value)
@@ -352,11 +428,11 @@ export async function validateJson(
         if (
           options.maxErrors &&
           options.maxErrors > 0 &&
-          errors.length > options.maxErrors
+          errorCount > options.maxErrors
         ) {
           resolve({
             valid: false,
-            errors: errors.slice(0, options.maxErrors),
+            errors: errors,
           })
           parser.end()
         }
@@ -396,4 +472,45 @@ export async function validateJson(
 
 export const JsonValidatorTwoZero = {
   validateJson,
+}
+
+function errorObjectToValidationErrorWithWarnings(
+  error: ErrorObject,
+  index: number,
+  errors: ErrorObject[]
+): ValidationError {
+  const validationError = errorObjectToValidationError(error)
+  // If a "payer specific negotiated charge" can only be expressed as a percentage or algorithm,
+  // then a corresponding "Estimated Allowed Amount" must also be encoded. Required beginning 1/1/2025.
+  // two validation errors occur for this conditional: one for the "required" keyword, one for the "if" keyword
+  if (
+    error.schemaPath ===
+    "#/definitions/payers_information/allOf/1/then/required"
+  ) {
+    validationError.warning = true
+  } else if (
+    error.schemaPath === "#/definitions/payers_information/allOf/1/if" &&
+    index > 0 &&
+    errors[index - 1].schemaPath ===
+      "#/definitions/payers_information/allOf/1/then/required"
+  ) {
+    validationError.warning = true
+  }
+  // If code type is NDC, then the corresponding drug unit of measure and drug type of measure data elements
+  // must be encoded. Required beginning 1/1/2025.
+  // two validation errors occur for this conditional: one for the "required" keyword, one for the "if" keyword
+  else if (
+    error.schemaPath === "#/then/required" &&
+    error.params.missingProperty === "drug_information"
+  ) {
+    validationError.warning = true
+  } else if (
+    error.schemaPath === "#/if" &&
+    index > 0 &&
+    errors[index - 1].schemaPath === "#/then/required" &&
+    errors[index - 1].params.missingProperty === "drug_information"
+  ) {
+    validationError.warning = true
+  }
+  return validationError
 }

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -391,9 +391,7 @@ export async function validateJson(
     // TODO: currently this is still storing the full array of items in "parent", but we
     // would need to override some internals to get around that
     parser.onValue = ({ value, key, stack }) => {
-      if (stack.length > 2 || key === "standard_charge_information") {
-        return
-      }
+      if (stack.length > 2 || key === "standard_charge_information") return
       if (typeof key === "string") {
         metadata[key] = value
       } else {
@@ -406,10 +404,16 @@ export async function validateJson(
                 ? errorObjectToValidationError
                 : errorObjectToValidationErrorWithWarnings
             )
-            .map((error) => ({
-              ...error,
-              path: error.path.replace(/\/0\//gi, `/${key}/`),
-            }))
+            .map((error) => {
+              const pathPrefix = stack
+                .filter((se) => se.key)
+                .map((se) => se.key)
+                .join("/")
+              return {
+                ...error,
+                path: `/${pathPrefix}/${key}${error.path}`,
+              }
+            })
           // if warning list is already full, don't add the new warnings
           if (
             options.maxErrors != null &&

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -177,13 +177,13 @@ test("validateJson estimated amount conditional", async (t) => {
   t.is(result.errors.length, 2)
   t.deepEqual(result.errors, [
     {
-      path: "/standard_charges/0/payers_information/3",
+      path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: "must have required property 'estimated_amount'",
       warning: enforce2025 ? undefined : true,
     },
     {
-      path: "/standard_charges/0/payers_information/3",
+      path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: 'must match "then" schema',
       warning: enforce2025 ? undefined : true,
@@ -201,13 +201,13 @@ test("validateJson NDC drug information conditional", async (t) => {
   t.is(result.errors.length, 2)
   t.deepEqual(result.errors, [
     {
-      path: "",
+      path: "/standard_charge_information/0",
       field: "",
       message: "must have required property 'drug_information'",
       warning: enforce2025 ? undefined : true,
     },
     {
-      path: "",
+      path: "/standard_charge_information/0",
       field: "",
       message: 'must match "then" schema',
       warning: enforce2025 ? undefined : true,
@@ -225,13 +225,13 @@ test("validateJson 2025 properties", async (t) => {
   t.is(result.errors.length, 3)
   t.deepEqual(result.errors, [
     {
-      path: "/drug_information",
+      path: "/standard_charge_information/0/drug_information",
       field: "drug_information",
       message: "must have required property 'type'",
       warning: enforce2025 ? undefined : true,
     },
     {
-      path: "/standard_charges/1/payers_information/1/estimated_amount",
+      path: "/standard_charge_information/1/standard_charges/0/payers_information/1/estimated_amount",
       field: "estimated_amount",
       message: "must be number",
       warning: enforce2025 ? undefined : true,

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -166,3 +166,51 @@ test("validateJsonConditionals", async (t) => {
     },
   ])
 })
+
+test("validateJson estimated amount conditional", async (t) => {
+  const enforce2025 = new Date().getFullYear() >= 2025
+  const result = await validateJson(
+    loadFixtureStream("/2.0/sample-conditional-error-estimate.json"),
+    "v2.0"
+  )
+  t.is(result.valid, true)
+  t.is(result.errors.length, 2)
+  t.deepEqual(result.errors, [
+    {
+      path: "/standard_charges/0/payers_information/3",
+      field: "3",
+      message: "must have required property 'estimated_amount'",
+      warning: enforce2025 ? undefined : true,
+    },
+    {
+      path: "/standard_charges/0/payers_information/3",
+      field: "3",
+      message: 'must match "then" schema',
+      warning: enforce2025 ? undefined : true,
+    },
+  ])
+})
+
+test("validateJson NDC drug information conditional", async (t) => {
+  const enforce2025 = new Date().getFullYear() >= 2025
+  const result = await validateJson(
+    loadFixtureStream("/2.0/sample-conditional-error-ndc.json"),
+    "v2.0"
+  )
+  t.is(result.valid, true)
+  t.is(result.errors.length, 2)
+  t.deepEqual(result.errors, [
+    {
+      path: "",
+      field: "",
+      message: "must have required property 'drug_information'",
+      warning: enforce2025 ? undefined : true,
+    },
+    {
+      path: "",
+      field: "",
+      message: 'must match "then" schema',
+      warning: enforce2025 ? undefined : true,
+    },
+  ])
+})

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -173,7 +173,7 @@ test("validateJson estimated amount conditional", async (t) => {
     loadFixtureStream("/2.0/sample-conditional-error-estimate.json"),
     "v2.0"
   )
-  t.is(result.valid, true)
+  t.is(result.valid, !enforce2025)
   t.is(result.errors.length, 2)
   t.deepEqual(result.errors, [
     {
@@ -197,7 +197,7 @@ test("validateJson NDC drug information conditional", async (t) => {
     loadFixtureStream("/2.0/sample-conditional-error-ndc.json"),
     "v2.0"
   )
-  t.is(result.valid, true)
+  t.is(result.valid, !enforce2025)
   t.is(result.errors.length, 2)
   t.deepEqual(result.errors, [
     {
@@ -210,6 +210,36 @@ test("validateJson NDC drug information conditional", async (t) => {
       path: "",
       field: "",
       message: 'must match "then" schema',
+      warning: enforce2025 ? undefined : true,
+    },
+  ])
+})
+
+test("validateJson 2025 properties", async (t) => {
+  const enforce2025 = new Date().getFullYear() >= 2025
+  const result = await validateJson(
+    loadFixtureStream("/2.0/sample-2025-properties.json"),
+    "v2.0"
+  )
+  t.is(result.valid, !enforce2025)
+  t.is(result.errors.length, 3)
+  t.deepEqual(result.errors, [
+    {
+      path: "/drug_information",
+      field: "drug_information",
+      message: "must have required property 'type'",
+      warning: enforce2025 ? undefined : true,
+    },
+    {
+      path: "/standard_charges/1/payers_information/1/estimated_amount",
+      field: "estimated_amount",
+      message: "must be number",
+      warning: enforce2025 ? undefined : true,
+    },
+    {
+      path: "/modifier_information/0",
+      field: "0",
+      message: "must have required property 'modifier_payer_information'",
       warning: enforce2025 ? undefined : true,
     },
   ])

--- a/test/fixtures/2.0/sample-2025-properties.json
+++ b/test/fixtures/2.0/sample-2025-properties.json
@@ -1,0 +1,200 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "hospital_location": ["West Mercy Hospital", "West Mercy Surgical Center"],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "affirmation": {
+    "affirmation": "To the best of its knowledge and belief, the hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date indicated.",
+    "confirm_affirmation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "estimated_amount": 23145.98,
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ],
+      "drug_information": {
+        "unit": "2.5"
+      }
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "estimated_amount": "105.34",
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "modifier_information": [
+    {
+      "description": "some kind of modifier",
+      "code": "50"
+    }
+  ]
+}

--- a/test/fixtures/2.0/sample-conditional-error-estimate.json
+++ b/test/fixtures/2.0/sample-conditional-error-estimate.json
@@ -62,8 +62,8 @@
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
               "standard_charge_percentage": 50,
-              "estimated_amount": 23145.98,
-              "methodology": "percent of total billed charges"
+              "methodology": "percent of total billed charges",
+              "additional_payer_notes": "this is missing an estimated_amount"
             }
           ]
         }
@@ -82,6 +82,8 @@
           "setting": "outpatient",
           "gross_charge": 150,
           "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
           "payers_information": [
             {
               "payer_name": "Platform Health Insurance",
@@ -114,36 +116,34 @@
         {
           "gross_charge": 2500,
           "discounted_cash": 2250,
-          "minimum": 2000,
+          "minimum": 1200,
+          "maximum": 2000,
           "setting": "inpatient",
           "payers_information": [
             {
               "payer_name": "Platform Health Insurance",
               "plan_name": "PPO",
-              "standard_charge_dollar": 115,
+              "standard_charge_dollar": 1500,
               "methodology": "per diem"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 2000,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 1-3"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 1800,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 4-5"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 1200,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 6+"
             }
@@ -164,6 +164,7 @@
           "gross_charge": 13000,
           "discounted_cash": 12000,
           "minimum": 8000,
+          "maximum": 10000,
           "setting": "outpatient",
           "payers_information": [
             {

--- a/test/fixtures/2.0/sample-conditional-error-ndc.json
+++ b/test/fixtures/2.0/sample-conditional-error-ndc.json
@@ -25,7 +25,7 @@
         },
         {
           "code": "175869",
-          "type": "LOCAL"
+          "type": "NDC"
         }
       ],
       "standard_charges": [
@@ -82,6 +82,8 @@
           "setting": "outpatient",
           "gross_charge": 150,
           "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
           "payers_information": [
             {
               "payer_name": "Platform Health Insurance",
@@ -114,36 +116,34 @@
         {
           "gross_charge": 2500,
           "discounted_cash": 2250,
-          "minimum": 2000,
+          "minimum": 1200,
+          "maximum": 2000,
           "setting": "inpatient",
           "payers_information": [
             {
               "payer_name": "Platform Health Insurance",
               "plan_name": "PPO",
-              "standard_charge_dollar": 115,
+              "standard_charge_dollar": 1500,
               "methodology": "per diem"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 2000,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 1-3"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 1800,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 4-5"
             },
             {
               "payer_name": "Region Health Insurance",
               "plan_name": "HMO",
-              "standard_charge_percentage": 115,
-              "estimated_amount": 22243.34,
+              "standard_charge_dollar": 1200,
               "methodology": "per diem",
               "additional_payer_notes": "per diem, days 6+"
             }
@@ -164,6 +164,7 @@
           "gross_charge": 13000,
           "discounted_cash": 12000,
           "minimum": 8000,
+          "maximum": 10000,
           "setting": "outpatient",
           "payers_information": [
             {


### PR DESCRIPTION
Some rules in the schema are not enforced until 2025. If these rules create errors, mark them as warnings. The number of warnings and errors are counted separately. If the maximum number of warnings is reached, further warnings are discarded, but validation continues. If all ValidationErrors are warnings, the file is considered valid.