### PR TITLE
Give path to missing column errors as row number

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -195,7 +195,7 @@ export function validateHeaderColumns(columns: string[]): {
       ...remainingColumns.map((requiredColumn) => {
         return csvErr(
           rowIndex,
-          columns.length,
+          -1,
           requiredColumn,
           ERRORS.HEADER_COLUMN_MISSING(requiredColumn)
         )
@@ -278,7 +278,7 @@ export function validateColumns(columns: string[]): CsvValidationError[] {
     ...remainingColumns.map((requiredColumn) => {
       const problem = csvErr(
         rowIndex,
-        columns.length,
+        -1,
         requiredColumn,
         ERRORS.COLUMN_MISSING(requiredColumn)
       )

--- a/src/versions/common/csv.ts
+++ b/src/versions/common/csv.ts
@@ -40,7 +40,7 @@ export function sepColumnsEqual(colA: string, colB: string) {
 export const ASCII_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 export function csvCellName(row: number, column: number): string {
-  return `${csvColumnName(column)}${row + 1}`
+  return `${(column ?? -1) >= 0 ? csvColumnName(column) : "row "}${row + 1}`
 }
 
 export function csvColumnName(column: number): string {

--- a/test/2.0/csv.e2e.spec.ts
+++ b/test/2.0/csv.e2e.spec.ts
@@ -28,7 +28,7 @@ test("validateCsvWideHeaderError", async (t) => {
   t.is(result.valid, false)
   t.deepEqual(result.errors, [
     {
-      path: "BA1",
+      path: "row 1",
       field: "hospital_location",
       message:
         'Header column "hospital_location" is miscoded or missing. You must include this header and confirm that it is encoded as specified in the data dictionary.',
@@ -80,7 +80,7 @@ test("validateCsvWideMissingMissingRequiredColumnError", async (t) => {
   t.is(result.valid, false)
   t.deepEqual(result.errors, [
     {
-      path: "BA3",
+      path: "row 3",
       field:
         "standard_charge | platform_health_insurance | ppo | negotiated_dollar",
       message:
@@ -103,13 +103,13 @@ test("validate columns with date-dependent enforcement", async (t) => {
     t.is(result.valid, false)
     t.deepEqual(result.errors, [
       {
-        path: "Y3",
+        path: "row 3",
         field: "drug_unit_of_measurement",
         message:
           "Column drug_unit_of_measurement is miscoded or missing from row 3. You must include this column and confirm that it is encoded as specified in the data dictionary.",
       },
       {
-        path: "Y3",
+        path: "row 3",
         field: "drug_type_of_measurement",
         message:
           "Column drug_type_of_measurement is miscoded or missing from row 3. You must include this column and confirm that it is encoded as specified in the data dictionary.",
@@ -123,14 +123,14 @@ test("validate columns with date-dependent enforcement", async (t) => {
     t.is(result.valid, true)
     t.deepEqual(result.errors, [
       {
-        path: "Y3",
+        path: "row 3",
         field: "drug_unit_of_measurement",
         message:
           "Column drug_unit_of_measurement is miscoded or missing from row 3. You must include this column and confirm that it is encoded as specified in the data dictionary.",
         warning: true,
       },
       {
-        path: "Y3",
+        path: "row 3",
         field: "drug_type_of_measurement",
         message:
           "Column drug_type_of_measurement is miscoded or missing from row 3. You must include this column and confirm that it is encoded as specified in the data dictionary.",


### PR DESCRIPTION
A missing column could be added anywhere in rows 1 and 3. Instead of specifying the cell at the end of the row, indicate that the whole row is the path.

If the column for a CSV error is undefined, indicate that the whole row is the path for the error.