### PR TITLE
Handle and report JSON parsing errors

### DIFF
--- a/src/versions/1.1/json.ts
+++ b/src/versions/1.1/json.ts
@@ -269,7 +269,7 @@ export async function validateJson(
     parser.onError = (e) => reject(e)
 
     // TODO: Assuming this must be awaited?
-    await parseJson(jsonInput, parser, reject)
+    await parseJson(jsonInput, parser)
   })
 }
 

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -504,7 +504,7 @@ export async function validateJson(
         errors: [
           {
             path: "",
-            message: `JSON parsing error: ${e.message}. Please check that your file is well-formatted JSON.`,
+            message: `JSON parsing error: ${e.message}. The validator is unable to review a syntactically invalid JSON file. Please ensure that your file is well-formatted JSON.`,
           },
         ],
       })

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -387,7 +387,7 @@ export async function validateJson(
   let warningCount = 0
   let errorCount = 0
 
-  return new Promise(async (resolve, reject) => {
+  return new Promise(async (resolve) => {
     // TODO: currently this is still storing the full array of items in "parent", but we
     // would need to override some internals to get around that
     parser.onValue = ({ value, key, stack }) => {
@@ -495,10 +495,22 @@ export async function validateJson(
       })
     }
 
-    parser.onError = (e) => reject(e)
+    parser.onError = (e) => {
+      parser.onEnd = () => null
+      parser.onError = () => null
+      parser.end()
+      resolve({
+        valid: false,
+        errors: [
+          {
+            path: "",
+            message: `JSON parsing error: ${e.message}. Please check that your file is well-formatted JSON.`,
+          },
+        ],
+      })
+    }
 
-    // TODO: Assuming this must be awaited?
-    await parseJson(jsonInput, parser, reject)
+    parseJson(jsonInput, parser)
   })
 }
 

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -20,6 +20,15 @@ test("validateJson empty", async (t) => {
   t.deepEqual(result.errors.length, 8)
 })
 
+test("validateJson syntactically invalid", async (t) => {
+  const result = await validateJson(
+    loadFixtureStream("/2.0/sample-invalid.json"),
+    "v2.0"
+  )
+  t.is(result.valid, false)
+  t.deepEqual(result.errors.length, 1)
+})
+
 test("validateJson maxErrors", async (t) => {
   const result = await validateJson(
     loadFixtureStream("/2.0/sample-empty.json"),

--- a/test/fixtures/2.0/sample-invalid.json
+++ b/test/fixtures/2.0/sample-invalid.json
@@ -1,0 +1,198 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-0701",
+  "version": "2.0.0"
+  "hospital_location": [
+    "West Mercy Hospital",
+    "West Mercy Surgical Center"
+  ],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "affirmation": {
+    "affirmation": "To the best of its knowledge and belief, the hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date indicated.",
+    "confirm_affirmation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "LOCAL"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "estimated_amount": 23145.98,
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "estimated_amount": 105.34,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Tested with the online validator and confirmed that the parse error is reported correctly. I would like to re-examine the way that callbacks/promises are being managed in the JSON validator implementation at some point, though.