### PR TITLE
Separate warning and error counts for CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpt-validator",
-  "version": "0.1.0-alpha.15",
+  "version": "1.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator",
-      "version": "0.1.0-alpha.15",
+      "version": "1.0.0-rc.4",
       "license": "CC0-1.0",
       "dependencies": {
         "@streamparser/json": "^0.0.17",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,33 @@
+export function addErrorsToList<T extends { warning?: boolean | undefined }>(
+  newErrors: T[],
+  errorList: T[],
+  maxErrors = 0,
+  counts: { errors: number; warnings: number }
+) {
+  // if warning list is already full, don't add the new warnings
+  if (maxErrors > 0 && counts.warnings >= maxErrors) {
+    newErrors = newErrors.filter((error) => error.warning !== true)
+    // only add enough to reach the limit
+    if (counts.errors + newErrors.length > maxErrors) {
+      newErrors = newErrors.slice(0, maxErrors - counts.errors)
+    }
+    errorList.push(...newErrors)
+    counts.errors += newErrors.length
+  } else {
+    newErrors.forEach((error) => {
+      if (error.warning) {
+        if (maxErrors <= 0 || counts.warnings < maxErrors) {
+          errorList.push(error)
+          counts.warnings++
+        }
+      } else {
+        if (maxErrors <= 0 || counts.errors < maxErrors) {
+          errorList.push(error)
+          counts.errors++
+        }
+      }
+    })
+  }
+
+  return counts
+}

--- a/test/csv.e2e.spec.ts
+++ b/test/csv.e2e.spec.ts
@@ -20,6 +20,12 @@ test("sample-1", async (t) => {
         path: "G4",
       },
       {
+        field: "standard_charge | contracting_method",
+        message:
+          '"standard_charge | contracting_method" value "another" is not one of the allowed values: "case rate", "fee schedule", "percent of total billed charges", "per diem", "other"',
+        path: "row 4",
+      },
+      {
         field: "code | 1 | type",
         message:
           '"code | 1 | type" value "d" is not one of the allowed values: "CPT", "HCPCS", "ICD", "MS-DRG", "R-DRG", "S-DRG", "APS-DRG", "AP-DRG", "APR-DRG", "APC", "NDC", "HIPPS", "LOCAL", "EAPG", "CDT", "RC", "CDM"',

--- a/test/csv.e2e.spec.ts
+++ b/test/csv.e2e.spec.ts
@@ -19,6 +19,19 @@ test("sample-1", async (t) => {
           '"setting" value "ipatient" is not one of the allowed values: "inpatient", "outpatient", "both"',
         path: "G4",
       },
+      {
+        field: "code | 1 | type",
+        message:
+          '"code | 1 | type" value "d" is not one of the allowed values: "CPT", "HCPCS", "ICD", "MS-DRG", "R-DRG", "S-DRG", "APS-DRG", "AP-DRG", "APR-DRG", "APC", "NDC", "HIPPS", "LOCAL", "EAPG", "CDT", "RC", "CDM"',
+        path: "C5",
+        warning: true,
+      },
+      {
+        field: "setting",
+        message:
+          '"setting" value "opatient" is not one of the allowed values: "inpatient", "outpatient", "both"',
+        path: "G5",
+      },
     ]
   )
 })
@@ -37,6 +50,12 @@ test("sample-1 maxErrors", async (t) => {
           '"code | 1 | type" value "c" is not one of the allowed values: "CPT", "HCPCS", "ICD", "MS-DRG", "R-DRG", "S-DRG", "APS-DRG", "AP-DRG", "APR-DRG", "APC", "NDC", "HIPPS", "LOCAL", "EAPG", "CDT", "RC", "CDM"',
         path: "C4",
         warning: true,
+      },
+      {
+        field: "setting",
+        message:
+          '"setting" value "ipatient" is not one of the allowed values: "inpatient", "outpatient", "both"',
+        path: "G4",
       },
     ]
   )

--- a/test/fixtures/sample-1.csv
+++ b/test/fixtures/sample-1.csv
@@ -1,5 +1,5 @@
 Hospital_name,last_updated_on,version,hospital_location,financial_aid_policy,license_number | MD,,,,,,,,,,,,,,
 Example Hospital,2/1/23,1.0.0,Woodlawn,See aid policy on site,12345678,,,,,,,,,,,,,,
 description,code | 1,code | 1 | type,code | 2,code | 2 | type,billing_class,setting,drug_unit_of_measurement,drug_type_of_measurement,modifiers,standard_charge | gross,standard_charge | discounted_cash,payer_name,plan_name,standard_charge | negotiated_dollar,standard_charge | negotiated_percent,standard_charge | min,standard_charge | max,standard_charge | contracting_method,additional_generic_notes
-Code 1,A123,C,,,Facility,ipatient,1,ML,,100,90,Payer,Plan,80,20,60,80,other,
+Code 1,A123,C,,,Facility,ipatient,1,ML,,100,90,Payer,Plan,80,20,60,80,another,
 Code 1,A456,D,,,Facility,opatient,1,ML,,100,90,Payer,Plan,80,20,60,80,other,

--- a/test/fixtures/sample-1.csv
+++ b/test/fixtures/sample-1.csv
@@ -2,3 +2,4 @@ Hospital_name,last_updated_on,version,hospital_location,financial_aid_policy,lic
 Example Hospital,2/1/23,1.0.0,Woodlawn,See aid policy on site,12345678,,,,,,,,,,,,,,
 description,code | 1,code | 1 | type,code | 2,code | 2 | type,billing_class,setting,drug_unit_of_measurement,drug_type_of_measurement,modifiers,standard_charge | gross,standard_charge | discounted_cash,payer_name,plan_name,standard_charge | negotiated_dollar,standard_charge | negotiated_percent,standard_charge | min,standard_charge | max,standard_charge | contracting_method,additional_generic_notes
 Code 1,A123,C,,,Facility,ipatient,1,ML,,100,90,Payer,Plan,80,20,60,80,other,
+Code 1,A456,D,,,Facility,opatient,1,ML,,100,90,Payer,Plan,80,20,60,80,other,


### PR DESCRIPTION
Both JSON and CSV now track warnings and errors separately. Stop accumulating at the limit, rather than potentially a little past it due to adding more than enough to meet the limit.