### PR TITLE
adding an additional check for the payer_information object to ensure that some standard charge is present

### DIFF
--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -95,6 +95,7 @@ const STANDARD_CHARGE_DEFINITIONS = {
           },
         },
       },
+      required: ["payers_information"],
     },
     else: {
       required: ["minimum", "maximum"],

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -79,6 +79,7 @@ const STANDARD_CHARGE_DEFINITIONS = {
             },
           },
         },
+        required: ["payers_information"],
       },
     ],
     if: {

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -92,43 +92,63 @@ test("validateJsonConditionals", async (t) => {
     "v2.0"
   )
   t.is(result2.valid, false)
-  t.deepEqual(result2.errors.length, 7)
+  t.deepEqual(result2.errors.length, 11)
   t.deepEqual(result2.errors, [
     {
-      path: "/standard_charge_information/1/standard_charges/0",
-      field: "0",
-      message: "must have required property 'gross_charge'",
+      path: '/standard_charge_information/0/standard_charges/0',
+      field: '0',
+      message: "must have required property 'gross_charge'"
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0",
-      field: "0",
-      message: "must have required property 'discounted_cash'",
+      path: '/standard_charge_information/0/standard_charges/0',
+      field: '0',
+      message: "must have required property 'discounted_cash'"
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
-      field: "0",
-      message: "must have required property 'standard_charge_dollar'",
+      path: '/standard_charge_information/0/standard_charges/0',
+      field: '0',
+      message: "must have required property 'payers_information'"
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
-      field: "0",
-      message: "must have required property 'standard_charge_algorithm'",
+      path: '/standard_charge_information/0/standard_charges/0',
+      field: '0',
+      message: 'must match a schema in anyOf'
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
-      field: "0",
-      message: "must have required property 'standard_charge_percentage'",
+      path: '/standard_charge_information/1/standard_charges/0',
+      field: '0',
+      message: "must have required property 'gross_charge'"
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
-      field: "0",
-      message: "must match a schema in anyOf",
+      path: '/standard_charge_information/1/standard_charges/0',
+      field: '0',
+      message: "must have required property 'discounted_cash'"
     },
     {
-      path: "/standard_charge_information/1/standard_charges/0",
-      field: "0",
-      message: "must match a schema in anyOf",
+      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
+      field: '0',
+      message: "must have required property 'standard_charge_dollar'"
     },
+    {
+      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
+      field: '0',
+      message: "must have required property 'standard_charge_algorithm'"
+    },
+    {
+      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
+      field: '0',
+      message: "must have required property 'standard_charge_percentage'"
+    },
+    {
+      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
+      field: '0',
+      message: 'must match a schema in anyOf'
+    },
+    {
+      path: '/standard_charge_information/1/standard_charges/0',
+      field: '0',
+      message: 'must match a schema in anyOf'
+    }
   ])
 
   const result3 = await validateJson(

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -95,60 +95,60 @@ test("validateJsonConditionals", async (t) => {
   t.deepEqual(result2.errors.length, 11)
   t.deepEqual(result2.errors, [
     {
-      path: '/standard_charge_information/0/standard_charges/0',
-      field: '0',
-      message: "must have required property 'gross_charge'"
+      path: "/standard_charge_information/0/standard_charges/0",
+      field: "0",
+      message: "must have required property 'gross_charge'",
     },
     {
-      path: '/standard_charge_information/0/standard_charges/0',
-      field: '0',
-      message: "must have required property 'discounted_cash'"
+      path: "/standard_charge_information/0/standard_charges/0",
+      field: "0",
+      message: "must have required property 'discounted_cash'",
     },
     {
-      path: '/standard_charge_information/0/standard_charges/0',
-      field: '0',
-      message: "must have required property 'payers_information'"
+      path: "/standard_charge_information/0/standard_charges/0",
+      field: "0",
+      message: "must have required property 'payers_information'",
     },
     {
-      path: '/standard_charge_information/0/standard_charges/0',
-      field: '0',
-      message: 'must match a schema in anyOf'
+      path: "/standard_charge_information/0/standard_charges/0",
+      field: "0",
+      message: "must match a schema in anyOf",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0',
-      field: '0',
-      message: "must have required property 'gross_charge'"
+      path: "/standard_charge_information/1/standard_charges/0",
+      field: "0",
+      message: "must have required property 'gross_charge'",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0',
-      field: '0',
-      message: "must have required property 'discounted_cash'"
+      path: "/standard_charge_information/1/standard_charges/0",
+      field: "0",
+      message: "must have required property 'discounted_cash'",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
-      field: '0',
-      message: "must have required property 'standard_charge_dollar'"
+      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
+      field: "0",
+      message: "must have required property 'standard_charge_dollar'",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
-      field: '0',
-      message: "must have required property 'standard_charge_algorithm'"
+      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
+      field: "0",
+      message: "must have required property 'standard_charge_algorithm'",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
-      field: '0',
-      message: "must have required property 'standard_charge_percentage'"
+      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
+      field: "0",
+      message: "must have required property 'standard_charge_percentage'",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0/payers_information/0',
-      field: '0',
-      message: 'must match a schema in anyOf'
+      path: "/standard_charge_information/1/standard_charges/0/payers_information/0",
+      field: "0",
+      message: "must match a schema in anyOf",
     },
     {
-      path: '/standard_charge_information/1/standard_charges/0',
-      field: '0',
-      message: 'must match a schema in anyOf'
-    }
+      path: "/standard_charge_information/1/standard_charges/0",
+      field: "0",
+      message: "must match a schema in anyOf",
+    },
   ])
 
   const result3 = await validateJson(

--- a/test/fixtures/2.0/sample-conditional-error-standardcharge.json
+++ b/test/fixtures/2.0/sample-conditional-error-standardcharge.json
@@ -35,40 +35,8 @@
         {
           "minimum": 20000,
           "maximum": 20000,
-          "setting": "inpatient",
-          "payers_information": [
-            {
-              "payer_name": "Platform Health Insurance",
-              "plan_name": "PPO",
-              "standard_charge_dollar": 20000,
-              "standard_charge_algorithm": "MS-DRG",
-              "estimated_amount": 22243.34,
-              "methodology": "case rate"
-            },
-            {
-              "payer_name": "Platform Health Insurance",
-              "plan_name": "PPO",
-              "standard_charge_dollar": 20000,
-              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
-              "estimated_amount": 22243.34,
-              "methodology": "case rate"
-            },
-            {
-              "payer_name": "Platform Health Insurance",
-              "plan_name": "PPO",
-              "standard_charge_dollar": 20000,
-              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
-              "estimated_amount": 22243.34,
-              "methodology": "case rate"
-            },
-            {
-              "payer_name": "Region Health Insurance",
-              "plan_name": "HMO",
-              "standard_charge_percentage": 50,
-              "estimated_amount": 23145.98,
-              "methodology": "percent of total billed charges"
-            }
-          ]
+          "setting": "inpatient"
+          
         }
       ]
     },


### PR DESCRIPTION
There was a situation where a JSON file could omit both the gross charge and cash price alone with the complete payers_information array and it would pass the validation although a standard charge was not present.

