### PR TITLE
checking for 0s in the typical standard charges

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -858,7 +858,8 @@ export function validateWideFields(
           ERRORS.INVALID_NUMBER(
             `estimated_amount | ${payer} | ${plan}`,
             row[`estimated_amount | ${payer} | ${plan}`]
-          )
+          ),
+          !enforceConditionals
         )
       )
     }

--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -715,27 +715,6 @@ export function validateWideFields(
       )
     }
   }
-  // payersPlans.forEach(([payer, plan]) => {
-  //   if (
-  //     (foundCodes &&
-  //       (row["standard_charge | gross"] || "").trim().length > 0) ||
-  //     (
-  //       row[`standard_charge | ${payer} | ${plan} | discounted_cash`] || ""
-  //     ).trim().length > 0 ||
-  //     (
-  //       row[`standard_charge | ${payer} | ${plan} | negotiated_dollar`] || ""
-  //     ).trim().length > 0 ||
-  //     (
-  //       row[`standard_charge | ${payer} | ${plan} | negotiated_percentage`] ||
-  //       ""
-  //     ).trim().length > 0 ||
-  //     (
-  //       row[`standard_charge | ${payer} | ${plan} | negotiated_algorithm`] || ""
-  //     ).trim().length > 0
-  //   ) {
-  //     // ? validate a required row ?
-  //   }
-  // })
 
   // If there is a "payer specific negotiated charge" encoded as a dollar amount,
   // there must be a corresponding valid value encoded for the deidentified minimum and deidentified maximum negotiated charge data.
@@ -803,6 +782,87 @@ export function validateWideFields(
     }
   })
 
+  // Ensuring that the numeric values are greater than zero.
+  payersPlans.forEach(([payer, plan]) => {
+    if (
+      (
+        row[`standard_charge | ${payer} | ${plan} | negotiated_dollar`] || ""
+      ).trim().length > 0 &&
+      validateRequiredFloatField(
+        row,
+        `standard_charge | ${payer} | ${plan} | negotiated_dollar`,
+        index,
+        columns.indexOf(
+          `standard_charge | ${payer} | ${plan} | negotiated_dollar`
+        )
+      ).length > 0
+    ) {
+      errors.push(
+        csvErr(
+          index,
+          columns.indexOf(
+            `standard_charge | ${payer} | ${plan} | negotiated_dollar`
+          ),
+          `standard_charge | ${payer} | ${plan} | negotiated_dollar`,
+          ERRORS.INVALID_NUMBER(
+            `standard_charge | ${payer} | ${plan} | negotiated_dollar`,
+            row[`standard_charge | ${payer} | ${plan} | negotiated_dollar`]
+          )
+        )
+      )
+    }
+
+    if (
+      (
+        row[`standard_charge | ${payer} | ${plan} | negotiated_percentage`] ||
+        ""
+      ).trim().length > 0 &&
+      validateRequiredFloatField(
+        row,
+        `standard_charge | ${payer} | ${plan} | negotiated_percentage`,
+        index,
+        columns.indexOf(
+          `standard_charge | ${payer} | ${plan} | negotiated_percentage`
+        )
+      ).length > 0
+    ) {
+      errors.push(
+        csvErr(
+          index,
+          columns.indexOf(
+            `standard_charge | ${payer} | ${plan} | negotiated_percentage`
+          ),
+          `standard_charge | ${payer} | ${plan} | negotiated_percentage`,
+          ERRORS.INVALID_NUMBER(
+            `standard_charge | ${payer} | ${plan} | negotiated_percentage`,
+            row[`standard_charge | ${payer} | ${plan} | negotiated_percentage`]
+          )
+        )
+      )
+    }
+
+    if (
+      (row[`estimated_amount | ${payer} | ${plan}`] || "").trim().length > 0 &&
+      validateRequiredFloatField(
+        row,
+        `estimated_amount | ${payer} | ${plan}`,
+        index,
+        columns.indexOf(`estimated_amount | ${payer} | ${plan}`)
+      ).length > 0
+    ) {
+      errors.push(
+        csvErr(
+          index,
+          columns.indexOf(`estimated_amount | ${payer} | ${plan}`),
+          `estimated_amount | ${payer} | ${plan}`,
+          ERRORS.INVALID_NUMBER(
+            `estimated_amount | ${payer} | ${plan}`,
+            row[`estimated_amount | ${payer} | ${plan}`]
+          )
+        )
+      )
+    }
+  })
   return errors
 }
 
@@ -1164,7 +1224,11 @@ function validateRequiredFloatField(
     return [
       csvErr(rowIndex, columnIndex, field, ERRORS.REQUIRED(field, suffix)),
     ]
-  } else if (!/^\d+(\.\d+)?$/g.test(row[field].trim())) {
+    // We wrap the three alternative patterns (\d+\.\d+|\.\d+|\d+) within a non-capturing group (?: ... ). This group acts as a container but doesn't capture any matched text during the regex search.
+  } else if (
+    !/^(?:\d+\.\d+|\.\d+|\d+)$/g.test(row[field].trim()) ||
+    parseFloat(row[field].trim()) <= 0
+  ) {
     return [
       csvErr(
         rowIndex,
@@ -1185,7 +1249,10 @@ function validateOptionalFloatField(
 ): CsvValidationError[] {
   if (!(row[field] || "").trim()) {
     return []
-  } else if (!/^\d+(\.\d+)?$/g.test(row[field].trim())) {
+  } else if (
+    !/^(?:\d+\.\d+|\.\d+|\d+)$/g.test(row[field].trim()) ||
+    parseFloat(row[field].trim()) <= 0
+  ) {
     return [
       csvErr(
         rowIndex,

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -1623,4 +1623,21 @@ test("validateRow wide conditionals", (t) => {
     modifierWithWrongTypesErrors[2].message,
     '"standard_charge | Payer Two | Special Plan | methodology" value "secret" is not one of the allowed valid values. You must encode one of these valid values: case rate, fee schedule, percent of total billed charges, per diem, other'
   )
+
+  const zeroNumericRow = {
+    ...basicRow,
+    "standard_charge | Payer One | Basic Plan | negotiated_dollar": "0",
+    "standard_charge | Payer One | Basic Plan | negotiated_percentage": "0",
+    "standard_charge | Payer One | Basic Plan | methodology": "per diem",
+  }
+  const zeroNumericRowErrors = validateRow(zeroNumericRow, 22, columns, true)
+  t.is(zeroNumericRowErrors.length, 2)
+  t.is(
+    zeroNumericRowErrors[0].message,
+    '"standard_charge | Payer One | Basic Plan | negotiated_dollar" value "0" is not a positive number. You must encode a positive, non-zero, numeric value.'
+  )
+  t.is(
+    zeroNumericRowErrors[1].message,
+    '"standard_charge | Payer One | Basic Plan | negotiated_percentage" value "0" is not a positive number. You must encode a positive, non-zero, numeric value.'
+  )
 })


### PR DESCRIPTION
The standard charges for CSV now allow for "0.5" and ".5" values for numeric data types. There is also a check that includes that the values are greater than 0.