### PR TITLE
Minimum conditional

### DIFF
--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -79,7 +79,7 @@ const STANDARD_CHARGE_DEFINITIONS = {
             },
           },
         },
-         required: ["payers_information"],
+        required: ["payers_information"],
       },
     ],
     if: {

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -79,7 +79,7 @@ const STANDARD_CHARGE_DEFINITIONS = {
             },
           },
         },
-        required: ["payers_information"],
+         required: ["payers_information"],
       },
     ],
     if: {
@@ -95,7 +95,6 @@ const STANDARD_CHARGE_DEFINITIONS = {
           },
         },
       },
-      required: ["payers_information"],
     },
     else: {
       required: ["minimum", "maximum"],

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -273,3 +273,11 @@ test("validateJson 2025 properties", async (t) => {
     },
   ])
 })
+
+test("validateJson minimum not required if there are no payer-specific standard charges", async (t) => {
+  const result = await validateJson(
+    loadFixtureStream("/2.0/sample-conditional-valid-minimum.json"),
+    "v2.0"
+  )
+  t.is(result.valid, true)
+})

--- a/test/fixtures/2.0/sample-conditional-valid-minimum.json
+++ b/test/fixtures/2.0/sample-conditional-valid-minimum.json
@@ -1,0 +1,42 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "hospital_location": [
+    "West Mercy Hospital",
+    "West Mercy Surgical Center"
+  ],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "affirmation": {
+    "affirmation": "To the best of its knowledge and belief, the hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date indicated.",
+    "confirm_affirmation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "LOCAL"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "inpatient",
+          "gross_charge": 1000
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Removing conditional logic that required the min/max attribute if there were no payer-specific standard charges.