### PR TITLE
minor refactor to remove the 'not' conditional language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpt-validator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@streamparser/json": "^0.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "Validation library for CMS Hospital Price Transparency machine-readable files",

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -87,16 +87,15 @@ const STANDARD_CHARGE_DEFINITIONS = {
       properties: {
         payers_information: {
           type: "array",
-          items: {
+          contains: {
             type: "object",
-            not: {
-              required: ["standard_charge_dollar"],
-            },
+            required: ["standard_charge_dollar"],
           },
         },
       },
+      required: ["payers_information"],
     },
-    else: {
+    then: {
       required: ["minimum", "maximum"],
     },
   },

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -171,7 +171,7 @@ test("validateJsonConditionals", async (t) => {
     {
       path: "/standard_charge_information/1/standard_charges/0",
       field: "0",
-      message: 'must match "else" schema',
+      message: 'must match "then" schema',
     },
     {
       path: "/standard_charge_information/2/standard_charges/0",
@@ -181,7 +181,7 @@ test("validateJsonConditionals", async (t) => {
     {
       path: "/standard_charge_information/2/standard_charges/0",
       field: "0",
-      message: 'must match "else" schema',
+      message: 'must match "then" schema',
     },
     {
       path: "/standard_charge_information/3/standard_charges/0",
@@ -191,7 +191,7 @@ test("validateJsonConditionals", async (t) => {
     {
       path: "/standard_charge_information/3/standard_charges/0",
       field: "0",
-      message: 'must match "else" schema',
+      message: 'must match "then" schema',
     },
   ])
 })


### PR DESCRIPTION
Even though the logic behind the conditionals have the same result, this refactor will be easier to maintain in the future and is also to match the schemas found in the Data Dictionary. 