### PR TITLE
Resolve CSV column off by one error

### DIFF
--- a/src/versions/common/csv.ts
+++ b/src/versions/common/csv.ts
@@ -47,7 +47,7 @@ export function csvColumnName(column: number): string {
   if (column < ASCII_UPPERCASE.length) return ASCII_UPPERCASE[column]
 
   return (
-    ASCII_UPPERCASE[Math.floor(column / ASCII_UPPERCASE.length)] +
+    ASCII_UPPERCASE[Math.floor(column / ASCII_UPPERCASE.length) - 1] +
     csvColumnName(column % ASCII_UPPERCASE.length)
   )
 }

--- a/test/common/csv.spec.ts
+++ b/test/common/csv.spec.ts
@@ -1,0 +1,7 @@
+import test from "ava"
+import { csvColumnName } from "../../src/versions/common/csv.js"
+
+test("csvColumnName", (t) => {
+  t.is(csvColumnName(0), "A")
+  t.is(csvColumnName(26), "AA")
+})


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Resolves issue with off-by-one errors for CSV column names

## Problem

Right now CSV column names skip straight from "Z" to "BA" rather than "AA", so there's an offset for all columns after this. This update supports everything up until AAA which is over 700 and seems unlikely.

## Solution

Subtract 1 from the ASCII index when the column name is two characters

## Test Plan

I added some simple test cases that demonstrate the problem and didn't previously exist for the function
