### PR TITLE
switching from recursion to a loop. In theory, determining the column name can go to infinity

### DIFF
--- a/src/versions/common/csv.ts
+++ b/src/versions/common/csv.ts
@@ -44,12 +44,12 @@ export function csvCellName(row: number, column: number): string {
 }
 
 export function csvColumnName(column: number): string {
-  if (column < ASCII_UPPERCASE.length) return ASCII_UPPERCASE[column]
-
-  return (
-    ASCII_UPPERCASE[Math.floor(column / ASCII_UPPERCASE.length) - 1] +
-    csvColumnName(column % ASCII_UPPERCASE.length)
-  )
+  let name = ""
+  while (column >= 0) {
+    name = ASCII_UPPERCASE[column % 26] + name
+    column = Math.floor(column / 26) - 1
+  }
+  return name
 }
 
 export function objectFromKeysValues(

--- a/src/versions/common/csv.ts
+++ b/src/versions/common/csv.ts
@@ -46,8 +46,8 @@ export function csvCellName(row: number, column: number): string {
 export function csvColumnName(column: number): string {
   let name = ""
   while (column >= 0) {
-    name = ASCII_UPPERCASE[column % 26] + name
-    column = Math.floor(column / 26) - 1
+    name = ASCII_UPPERCASE[column % ASCII_UPPERCASE.length] + name
+    column = Math.floor(column / ASCII_UPPERCASE.length) - 1
   }
   return name
 }

--- a/test/common/csv.spec.ts
+++ b/test/common/csv.spec.ts
@@ -4,4 +4,7 @@ import { csvColumnName } from "../../src/versions/common/csv.js"
 test("csvColumnName", (t) => {
   t.is(csvColumnName(0), "A")
   t.is(csvColumnName(26), "AA")
+  t.is(csvColumnName(702), "AAA")
+  t.is(csvColumnName(18278), "AAAA")
+  t.is(csvColumnName(475254), "AAAAA")
 })


### PR DESCRIPTION
One line description of your change (less than 72 characters)
===
Allows for any number of columns for the CSV wide template.

Problem
===
[The previous update](https://github.com/CMSgov/hpt-validator/pull/35) supported columns up to AAA (roughly 700 column), but then provides an `undefined` in the string that is being constructed afterwards. 

Solution
===
Changed the recursive solution for one with a loop and builds out the string that way. Now the column size can grow to any length, though highly unlikely.

Test Plan
===
I added some simple test cases that demonstrate the problem and didn't previously exist for the function