### PR TITLE
Non-required column header duplicate bug.

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -269,6 +269,9 @@ export function validateColumns(columns: string[]): CsvValidationError[] {
         duplicateErrors.push(
           csvErr(rowIndex, index, "column", ERRORS.DUPLICATE_COLUMN(column))
         )
+      } else {
+        // Even if the column isn't part of the calculated remainingColumns, we still want to add it to the discoveredColumns array
+        discoveredColumns[index] = column
       }
     }
   })

--- a/src/versions/common/csv.ts
+++ b/src/versions/common/csv.ts
@@ -34,7 +34,10 @@ export function cleanColumnNames(columns: string[]) {
 export function sepColumnsEqual(colA: string, colB: string) {
   const cleanA = colA.split("|").map((v) => v.trim().toUpperCase())
   const cleanB = colB.split("|").map((v) => v.trim().toUpperCase())
-  return cleanA.every((a, idx: number) => a === cleanB[idx])
+  return (
+    cleanA.length === cleanB.length &&
+    cleanA.every((a, idx: number) => a === cleanB[idx])
+  )
 }
 
 export const ASCII_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -957,6 +957,16 @@ test("validateColumns wide", (t) => {
     "estimated_amount | Payer One | Basic Plan",
     "additional_payer_notes | Payer One | Basic Plan",
   ]
+
+  //The idea is that a column could be misnamed.
+  const additionalColumns = [
+    "standard_charge|[payer_AETNA LIFE AND CAUSAULTY | HMO/PPO]",
+    "standard_charge|[payer_AETNA LIFE AND CAUSAULTY | HMO/PPO] |percent",
+    "standard_charge|[payer_AETNA LIFE AND CAUSAULTY | HMO/PPO] |contracting_method",
+    "additional_payer_notes |[payer_AETNA LIFE AND CAUSAULTY | HMO/PPO]",
+    "standard_charge|[payer_ASR HEALTH BEN CIGNA |  COMMERCIAL]",
+    "standard_charge|[payer_ASR HEALTH BEN CIGNA |  COMMERCIAL]",
+  ]
   t.is(validateColumns(columns).length, 0)
   // any order is okay
   const reverseColumns = [...columns].reverse()
@@ -977,6 +987,11 @@ test("validateColumns wide", (t) => {
     "Column additional_payer_notes | Payer One | Basic Plan is miscoded or missing from row 3. You must include this column and confirm that it is encoded as specified in the data dictionary."
   )
   t.is(someColumnsMissingErrors[1].warning, undefined)
+
+  const customWideColumns = [...columns, ...additionalColumns]
+
+  const someDuplicateErrors = validateColumns(customWideColumns)
+  t.is(someDuplicateErrors.length, 12)
 })
 
 test("validateRow wide conditionals", (t) => {


### PR DESCRIPTION
## One line description of your change (less than 72 characters)
Detects for duplicates of non-required columns and allows for non-required columns not to trigger duplicate errors when there are none.

## Problem
Subtle bug that will trigger duplicate column error when comparing two values that are not duplicates. In addition, duplicates could not be triggered if the column headers were not part of the original expected set and there were actually duplicate column headers in the file.

## Solution

Added functionality to detect duplicates when column headers are not part of the initially calculated required headers for CSV wide

## Result

Duplicate non-required column headers will trigger an error. And false-positive duplicate errors will no longer be thrown.

## Test Plan

Extended the test suite to cover for this situation.
