### PR TITLE
Ambiguous CSV format error should always be on row 3

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -252,7 +252,7 @@ export function validateColumns(columns: string[]): CsvValidationError[] {
   const rowIndex = 2
 
   if (isAmbiguousFormat(columns)) {
-    return [csvErr(rowIndex + 1, -1, "", ERRORS.AMBIGUOUS_FORMAT())]
+    return [csvErr(rowIndex, -1, "", ERRORS.AMBIGUOUS_FORMAT())]
   }
 
   const tall = isTall(columns)

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -268,6 +268,9 @@ test("isAmbiguousFormat", (t) => {
     basicResultAmbiguousError1[0].message,
     "Required payer-specific information data element headers are missing or miscoded from the MRF that does not follow the specifications for the CSV “Tall” or CSV “Wide” format."
   )
+  // the ambiguous row error is always in row 3 of the csv
+  // but csv rows are 1-indexed, and error rows are 0-indexed, so we expect 2
+  t.is(basicResultAmbiguousError1[0].row, 2)
 
   const basicResultAmbiguousError2 = validateColumns(columnsAmbiguous2)
   t.is(basicResultAmbiguousError2.length, 1)
@@ -275,6 +278,7 @@ test("isAmbiguousFormat", (t) => {
     basicResultAmbiguousError2[0].message,
     "Required payer-specific information data element headers are missing or miscoded from the MRF that does not follow the specifications for the CSV “Tall” or CSV “Wide” format."
   )
+  t.is(basicResultAmbiguousError2[0].row, 2)
 })
 
 test("validateRow tall", (t) => {


### PR DESCRIPTION
Rows in the error object are 0-indexed, so the row property has a value of 2. This results in the eventual output being row 3.