### PR TITLE
Use matchesString in required enum check

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -1295,10 +1295,7 @@ function validateRequiredEnumField(
       csvErr(rowIndex, columnIndex, field, ERRORS.REQUIRED(field, suffix)),
     ]
   } else {
-    const uppercaseValue = row[field].toUpperCase()
-    if (
-      !allowedValues.some((allowed) => allowed.toUpperCase() === uppercaseValue)
-    ) {
+    if (!allowedValues.some((allowed) => matchesString(row[field], allowed))) {
       return [
         csvErr(
           rowIndex,

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -91,6 +91,19 @@ test("validateHeaderRow", (t) => {
     ]).length,
     0
   )
+  // leading and trailing spaces are allowed, and comparisons are not case-sensitive
+  t.is(
+    validateHeaderRow(VALID_HEADER_COLUMNS, [
+      "name",
+      "2022-01-01",
+      "1.0.0",
+      "Woodlawn",
+      "123 Address",
+      "001 | MD",
+      " TRUE ",
+    ]).length,
+    0
+  )
   const missingNameErrors = validateHeaderRow(VALID_HEADER_COLUMNS, [
     "",
     "2022-01-01",


### PR DESCRIPTION
`matchesString` should be used for all string comparisons in order to guarantee case-insensitivity and allow for leading and trailing spaces.