### PR TITLE
Do not validate defined optional elements

### DIFF
--- a/src/versions/1.1/csv.ts
+++ b/src/versions/1.1/csv.ts
@@ -9,10 +9,8 @@ import {
 import {
   BILLING_CODE_TYPES,
   BillingCodeType,
-  CHARGE_BILLING_CLASSES,
   CHARGE_SETTINGS,
   CONTRACTING_METHODS,
-  ChargeBillingClass,
   ChargeSetting,
   ContractingMethod,
   DRUG_UNITS,
@@ -24,13 +22,11 @@ export const HEADER_COLUMNS = [
   "last_updated_on",
   "version",
   "hospital_location",
-  "financial_aid_policy",
   "license_number | state",
 ]
 
 export const BASE_COLUMNS = [
   "description",
-  "billing_class",
   "setting",
   "drug_unit_of_measurement",
   "drug_type_of_measurement",
@@ -238,23 +234,6 @@ export function validateRow(
           "code | 2 | type",
           row["code | 2 | type"],
           BILLING_CODE_TYPES as unknown as string[]
-        )
-      )
-    )
-  }
-
-  if (
-    !CHARGE_BILLING_CLASSES.includes(row["billing_class"] as ChargeBillingClass)
-  ) {
-    errors.push(
-      csvErr(
-        index,
-        columns.indexOf("billing_class"),
-        "billing_class",
-        ERRORS.ALLOWED_VALUES(
-          "billing_class",
-          row["billing_class"],
-          CHARGE_BILLING_CLASSES as unknown as string[]
         )
       )
     )
@@ -477,7 +456,6 @@ export function getBaseColumns(columns: string[]): string[] {
   return [
     "description",
     ...codeColumns,
-    "billing_class",
     "setting",
     "drug_unit_of_measurement",
     "drug_type_of_measurement",

--- a/src/versions/1.1/json.ts
+++ b/src/versions/1.1/json.ts
@@ -10,7 +10,6 @@ import {
 } from "../../types.js"
 import {
   BILLING_CODE_TYPES,
-  CHARGE_BILLING_CLASSES,
   CHARGE_SETTINGS,
   DRUG_UNITS,
   CONTRACTING_METHODS,
@@ -57,10 +56,6 @@ const STANDARD_CHARGE_DEFINITIONS = {
         type: "array",
         items: { $ref: "#/definitions/payers_information" },
         minItems: 1,
-      },
-      billing_class: {
-        enum: CHARGE_BILLING_CLASSES,
-        type: "string",
       },
       additional_generic_notes: { type: "string" },
     },
@@ -157,7 +152,6 @@ export const METADATA_PROPERTIES = {
   },
   version: { type: "string" },
   hospital_location: { type: "string" },
-  financial_aid_policy: { type: "string" },
 }
 
 export const METADATA_REQUIRED = ["hospital_name", "last_updated_on", "version"]

--- a/src/versions/1.1/types.ts
+++ b/src/versions/1.1/types.ts
@@ -28,10 +28,6 @@ export const CHARGE_SETTINGS = ["inpatient", "outpatient", "both"] as const
 type ChargeSettingTuple = typeof CHARGE_SETTINGS
 export type ChargeSetting = ChargeSettingTuple[number]
 
-export const CHARGE_BILLING_CLASSES = ["professional", "facility"] as const
-type ChargeBillingClassTuple = typeof CHARGE_BILLING_CLASSES
-export type ChargeBillingClass = ChargeBillingClassTuple[number]
-
 export const CONTRACTING_METHODS = [
   "case rate",
   "fee schedule",

--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -10,7 +10,6 @@ import {
 } from "../common/csv.js"
 import {
   BILLING_CODE_TYPES,
-  CHARGE_BILLING_CLASSES,
   CHARGE_SETTINGS,
   STANDARD_CHARGE_METHODOLOGY,
   DRUG_UNITS,
@@ -41,11 +40,6 @@ export const BASE_COLUMNS = [
   "standard_charge | min", // positive number or blank
   "standard_charge | max", // positive number or blank
   "additional_generic_notes", // string
-]
-
-export const OPTIONAL_COLUMNS = [
-  "financial_aid_policy", // string
-  "billing_class", // CHARGE_BILLING_CLASSES or blank
 ]
 
 export const TALL_COLUMNS = [
@@ -388,16 +382,6 @@ export function validateRow(
   }
 
   errors.push(
-    ...validateOptionalEnumField(
-      row,
-      "billing_class",
-      index,
-      columns.indexOf("billing_class"),
-      CHARGE_BILLING_CLASSES
-    )
-  )
-
-  errors.push(
     ...validateRequiredEnumField(
       row,
       "setting",
@@ -555,16 +539,6 @@ function validateModifierRow(
   }
 
   // other conditionals don't apply for modifier rows, but any values entered should still be the correct type
-  errors.push(
-    ...validateOptionalEnumField(
-      row,
-      "billing_class",
-      index,
-      columns.indexOf("billing_class"),
-      CHARGE_BILLING_CLASSES
-    )
-  )
-
   errors.push(
     ...validateOptionalEnumField(
       row,

--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -10,7 +10,6 @@ import {
 } from "../../types.js"
 import {
   BILLING_CODE_TYPES,
-  CHARGE_BILLING_CLASSES,
   CHARGE_SETTINGS,
   DRUG_UNITS,
   STANDARD_CHARGE_METHODOLOGY,
@@ -54,10 +53,6 @@ const STANDARD_CHARGE_DEFINITIONS = {
         type: "array",
         items: { $ref: "#/definitions/payers_information" },
         minItems: 1,
-      },
-      billing_class: {
-        enum: CHARGE_BILLING_CLASSES,
-        type: "string",
       },
       additional_generic_notes: { type: "string" },
     },

--- a/src/versions/2.0/types.ts
+++ b/src/versions/2.0/types.ts
@@ -30,14 +30,6 @@ export const CHARGE_SETTINGS = ["inpatient", "outpatient", "both"] as const
 type ChargeSettingTuple = typeof CHARGE_SETTINGS
 export type ChargeSetting = ChargeSettingTuple[number]
 
-export const CHARGE_BILLING_CLASSES = [
-  "professional",
-  "facility",
-  "both",
-] as const
-type ChargeBillingClassTuple = typeof CHARGE_BILLING_CLASSES
-export type ChargeBillingClass = ChargeBillingClassTuple[number]
-
 export const STANDARD_CHARGE_METHODOLOGY = [
   "case rate",
   "fee schedule",


### PR DESCRIPTION
There are elements defined in the data dictionary that are specified as being optional. These elements have types defined in the data dictionary. Do not validate that these type requirements are fulfilled when the elements are present.

Tests that confirmed the validation of these elements should have existed previously, but they didn't, so there are no tests to remove.