### PR TITLE
Match metadata paths in JSON parser

### DIFF
--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -371,7 +371,17 @@ export async function validateJson(
   const validator = new Ajv({ allErrors: true })
   addFormats(validator)
   const parser = new JSONParser({
-    paths: ["$.*", "$.standard_charge_information.*"],
+    paths: [
+      "$.hospital_name",
+      "$.last_updated_on",
+      "$.license_information",
+      "$.version",
+      "$.hospital_address",
+      "$.hospital_location",
+      "$.affirmation",
+      "$.modifier_information",
+      "$.standard_charge_information.*",
+    ],
     keepStack: false,
   })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Match metadata paths in JSON parser

## Problem

Node may run out of available memory if input JSON contains large top-level elements that are matched by the parser's `$.*` path.

## Solution

Specify paths for defined metadata elements instead of matching all top-level elements. This allows the parser to skip undefined elements, which reduces memory usage for parsing.

## Result

Validator will be able to run on JSON files containing large top-level elements without exhausting available memory.

## Test Plan

Code was tested using JSON HPT MRF that contained its standard charge information in a top-level element with a key not defined by the schema. The file was large enough such that prior to the change, Node ran out of heap space. Specifically, the file was 1GB, and Node was configured with the default heap size. After the change, the validator was able to finish running and return a result object.
