### PR TITLE
CSV: Messages about modifiers are warnings until 2025

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -502,14 +502,15 @@ function validateModifierRow(
         " for wide format when a modifier is encoded without an item or service"
       ).length > 0
     ) {
-      errors.push(
-        csvErr(
+      errors.push({
+        ...csvErr(
           index,
           columns.indexOf(modifierRequiredFields[0]),
           modifierRequiredFields[0],
           ERRORS.MODIFIER_EXTRA_INFO()
-        )
-      )
+        ),
+        warning: !enforce2025,
+      })
     }
   } else {
     const modifierRequiredFields = [
@@ -527,14 +528,15 @@ function validateModifierRow(
         " for tall format when a modifier is encoded without an item or service"
       ).length > 0
     ) {
-      errors.push(
-        csvErr(
+      errors.push({
+        ...csvErr(
           index,
           columns.indexOf(modifierRequiredFields[0]),
           modifierRequiredFields[0],
           ERRORS.MODIFIER_EXTRA_INFO()
-        )
-      )
+        ),
+        warning: !enforce2025,
+      })
     }
   }
 

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -942,6 +942,7 @@ test("validateRow tall conditionals", (t) => {
     invalidModifierErrors[0].message,
     "If a modifier is encoded without an item or service, then a description and one of the following is the minimum information required: additional_payer_notes, standard_charge | negotiated_dollar, standard_charge | negotiated_percentage, or standard_charge | negotiated_algorithm."
   )
+  t.is(invalidModifierErrors[0].warning, !enforceConditionals)
   const modifierWithNotesRow = {
     ...basicRow,
     "code | 1": "",
@@ -1642,6 +1643,7 @@ test("validateRow wide conditionals", (t) => {
     invalidModifierErrors[0].message,
     "If a modifier is encoded without an item or service, then a description and one of the following is the minimum information required: additional_payer_notes, standard_charge | negotiated_dollar, standard_charge | negotiated_percentage, or standard_charge | negotiated_algorithm."
   )
+  t.is(invalidModifierErrors[0].warning, !enforceConditionals)
   const modifierWithGenericNotesRow = {
     ...basicRow,
     "code | 1": "",


### PR DESCRIPTION
## Problem

It is not yet 2025, but messages regarding modifier additional information are marked as errors, not warnings, when validating a CSV.

## Solution

When validating a CSV, the error that results if a modifier is missing necessary additional information is marked as a warning if the system date is before 2025.

## Test Plan

Test cases for modifier additional information are updated to check the warning flag of the error object.
