### PR TITLE
Fix for issue with parsing CSVs with mixed newline delimiters

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -183,6 +183,7 @@ export async function validateCsv(
   return new Promise((resolve, reject) => {
     Papa.parse(input, {
       header: false,
+      newline: "\n",
       // chunkSize: 64 * 1024,
       beforeFirstChunk: (chunk) => {
         return removeBOM(chunk)

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -181,10 +181,8 @@ export async function validateCsv(
   }
 
   return new Promise((resolve, reject) => {
-    Papa.parse(input, {
+    const config = {
       header: false,
-      newline: "\n",
-      // chunkSize: 64 * 1024,
       beforeFirstChunk: (chunk) => {
         return removeBOM(chunk)
       },
@@ -197,6 +195,12 @@ export async function validateCsv(
       },
       complete: () => handleParseEnd(resolve),
       error: (error: Error) => reject(error),
-    })
+    };
+
+    if (options.newline) {
+      config.newline = options.newline;
+    }
+
+    Papa.parse(input, config)
   })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,11 +44,13 @@ export interface CsvValidatorVersion {
 
 export interface CsvValidationOptions {
   maxErrors?: number
+  newline?: string
   onValueCallback?: (value: { [key: string]: string }) => void
 }
 
 export interface JsonValidatorOptions {
   maxErrors?: number
+  newline?: string
   onValueCallback?: (
     val: JsonTypes.JsonPrimitive | JsonTypes.JsonStruct
   ) => void


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- eslint and prettier should be run against all files and will be checked by CI.

-->

## One line description of your change (less than 72 characters)

Adds the newline param to the config for papaparse during csv parsing


## Problem
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of being the motivation for your change.
-->
Issue described [here](https://github.com/CMSgov/hpt-validator-cli/issues/29)

Basically if a file has the first line delimited by `\r\n` but the rest of the file is `\n`, then papaparse has trouble inferring which delimieter to use.

## Solution
<!--
Describe the modifications you've done.
-->

This PR uses the suggestion [here](https://github.com/mholt/PapaParse/issues/289#issuecomment-182451591) from the papaparse maintainer to set the `newline` config param.

This uses input from the user (provided from `hpt-validator-cli`) to add `newline` to the config. If no `newline` option is provided, it is not added to the config and papaparse should continue behaving as before (detecting the newline on its own)

For files with mixed line endings, the papaparse maintainers say you can set `\n` as the newline delimiter and then subsequently strip out the `\r` from the resulting rows, but I am not sure the latter part is necessary for this implementation.

## Result
<!--
What will change as a result of your pull request? Note that sometimes this
section is unnecessary because it is self-explanatory based on the solution.
-->

Solves [issue 29](https://github.com/CMSgov/hpt-validator-cli/issues/29)

<!--
Some important notes regarding the summary line:

- Describe what was done; not the result
- Use the active voice
- Use the present tense
- Capitalize properly
- Do not end in a period — this is a title/subject
- Prefix the subject with its scope
-->

## Test Plan

(Write your test plan here. If you changed any code, please provide us with
clear instructions on how you verified your changes work.)

To verify change works:
1. Download csv snippets from [issue 29](https://github.com/CMSgov/hpt-validator-cli/issues/29)
2. Attempt to validate both with changes in this PR
3. Verify output is the same for both (no warnings or errors)
4. Download `https://msc.rochesterregional.org/practitionerPortal/docs/161012691_canton-potsdam-hospital_standardcharges.csv` that is linked in the above issue
5. Attempt to validate both with changes in this PR
6. Verify that validation completes and finds no errors

Steps taken to verify this change does not alter working validations:
- [x] Select 100 MRFs in our database that were verified to be compliant according to the validator
- [x] Validate them using changes in this PR
- [x] Verify that output is the same

To do for more confidence
- [ ] Run on MRFs that were verified to be non-compliant according to the validator
- [ ] Run on a larger selection of both compliant and non-compliant MRFs
