### PR TITLE
Fix January 2025 enforcement tests

### DIFF
--- a/test/2.0/csv.e2e.spec.ts
+++ b/test/2.0/csv.e2e.spec.ts
@@ -144,7 +144,8 @@ test("validate columns with date-dependent enforcement", async (t) => {
       },
       {
         path: "A1",
-        message: "Errors were seen in headers so rows were not evaluated",
+        message:
+          "Errors were found in the headers or values in rows 1 through 3, so the remaining rows were not evaluated.",
       },
     ])
   } else {

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -361,7 +361,7 @@ test("validateRow tall", (t) => {
     emptyDrugUnitResult[0].message,
     'A value is required for "drug_unit_of_measurement" when "drug_type_of_measurement" is present. You must encode the missing information.'
   )
-  t.assert(emptyDrugUnitResult[0].warning === !enforce2025)
+  t.assert(emptyDrugUnitResult[0].warning === (enforce2025 ? undefined : true))
   const wrongDrugUnitRow = { ...basicRow, drug_unit_of_measurement: "-4" }
   const wrongDrugUnitResult = validateRow(wrongDrugUnitRow, 10, columns, false)
   t.is(wrongDrugUnitResult.length, 1)
@@ -369,7 +369,7 @@ test("validateRow tall", (t) => {
     wrongDrugUnitResult[0].message,
     '"drug_unit_of_measurement" value "-4" is not a positive number. You must encode a positive, non-zero, numeric value.'
   )
-  t.assert(wrongDrugUnitResult[0].warning === !enforce2025)
+  t.assert(wrongDrugUnitResult[0].warning === (enforce2025 ? undefined : true))
   // drug_type_of_measurement must be one of DRUG_UNITS if present
   const emptyDrugTypeRow = { ...basicRow, drug_type_of_measurement: "" }
   const emptyDrugTypeResult = validateRow(emptyDrugTypeRow, 12, columns, false)
@@ -378,7 +378,7 @@ test("validateRow tall", (t) => {
     emptyDrugTypeResult[0].message,
     'A value is required for "drug_type_of_measurement" when "drug_unit_of_measurement" is present. You must encode the missing information.'
   )
-  t.assert(emptyDrugTypeResult[0].warning === !enforce2025)
+  t.assert(emptyDrugTypeResult[0].warning === (enforce2025 ? undefined : true))
   const wrongDrugTypeRow = { ...basicRow, drug_type_of_measurement: "KG" }
   const wrongDrugTypeResult = validateRow(wrongDrugTypeRow, 12, columns, false)
   t.is(wrongDrugTypeResult.length, 1)
@@ -386,7 +386,7 @@ test("validateRow tall", (t) => {
     wrongDrugTypeResult[0].message,
     '"drug_type_of_measurement" value "KG" is not one of the allowed valid values. You must encode one of these valid values: GR, ME, ML, UN, F2, EA, GM'
   )
-  t.assert(wrongDrugTypeResult[0].warning === !enforce2025)
+  t.assert(wrongDrugTypeResult[0].warning === (enforce2025 ? undefined : true))
   // standard_charge | gross must be positive number if present
   const emptyGrossRow = { ...basicRow, "standard_charge | gross": "" }
   const emptyGrossResult = validateRow(emptyGrossRow, 13, columns, false)

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -218,13 +218,13 @@ test("validateJson estimated amount conditional", async (t) => {
       path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: "must have required property 'estimated_amount'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: 'must match "then" schema',
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
 })
@@ -242,13 +242,13 @@ test("validateJson NDC drug information conditional", async (t) => {
       path: "/standard_charge_information/0",
       field: "",
       message: "must have required property 'drug_information'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/0",
       field: "",
       message: 'must match "then" schema',
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
 })
@@ -266,19 +266,19 @@ test("validateJson 2025 properties", async (t) => {
       path: "/standard_charge_information/0/drug_information",
       field: "drug_information",
       message: "must have required property 'type'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/1/standard_charges/0/payers_information/1/estimated_amount",
       field: "estimated_amount",
       message: "must be number",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/modifier_information/0",
       field: "0",
       message: "must have required property 'modifier_payer_information'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
 })


### PR DESCRIPTION
Fix out-of-date error messages in January 2025 requirements tests.
Fix check for "warning" attribute in January 2025 requirements tests.