### PR TITLE
Fix extraneous error from prescription drug requirement

### DIFF
--- a/src/versions/2.0/json.ts
+++ b/src/versions/2.0/json.ts
@@ -123,9 +123,11 @@ const STANDARD_CHARGE_DEFINITIONS = {
                 const: "NDC",
               },
             },
+            required: ["type"],
           },
         },
       },
+      required: ["code_information"],
     },
     then: {
       required: ["drug_information"],
@@ -212,9 +214,11 @@ const STANDARD_CHARGE_PROPERTIES = {
               const: "NDC",
             },
           },
+          required: ["type"],
         },
       },
     },
+    required: ["code_information"],
   },
   then: {
     required: ["drug_information"],

--- a/test/2.0/csv.e2e.spec.ts
+++ b/test/2.0/csv.e2e.spec.ts
@@ -144,7 +144,8 @@ test("validate columns with date-dependent enforcement", async (t) => {
       },
       {
         path: "A1",
-        message: "Errors were seen in headers so rows were not evaluated",
+        message:
+          "Errors were found in the headers or values in rows 1 through 3, so the remaining rows were not evaluated.",
       },
     ])
   } else {

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -361,7 +361,7 @@ test("validateRow tall", (t) => {
     emptyDrugUnitResult[0].message,
     'A value is required for "drug_unit_of_measurement" when "drug_type_of_measurement" is present. You must encode the missing information.'
   )
-  t.assert(emptyDrugUnitResult[0].warning === !enforce2025)
+  t.assert(emptyDrugUnitResult[0].warning === (enforce2025 ? undefined : true))
   const wrongDrugUnitRow = { ...basicRow, drug_unit_of_measurement: "-4" }
   const wrongDrugUnitResult = validateRow(wrongDrugUnitRow, 10, columns, false)
   t.is(wrongDrugUnitResult.length, 1)
@@ -369,7 +369,7 @@ test("validateRow tall", (t) => {
     wrongDrugUnitResult[0].message,
     '"drug_unit_of_measurement" value "-4" is not a positive number. You must encode a positive, non-zero, numeric value.'
   )
-  t.assert(wrongDrugUnitResult[0].warning === !enforce2025)
+  t.assert(wrongDrugUnitResult[0].warning === (enforce2025 ? undefined : true))
   // drug_type_of_measurement must be one of DRUG_UNITS if present
   const emptyDrugTypeRow = { ...basicRow, drug_type_of_measurement: "" }
   const emptyDrugTypeResult = validateRow(emptyDrugTypeRow, 12, columns, false)
@@ -378,7 +378,7 @@ test("validateRow tall", (t) => {
     emptyDrugTypeResult[0].message,
     'A value is required for "drug_type_of_measurement" when "drug_unit_of_measurement" is present. You must encode the missing information.'
   )
-  t.assert(emptyDrugTypeResult[0].warning === !enforce2025)
+  t.assert(emptyDrugTypeResult[0].warning === (enforce2025 ? undefined : true))
   const wrongDrugTypeRow = { ...basicRow, drug_type_of_measurement: "KG" }
   const wrongDrugTypeResult = validateRow(wrongDrugTypeRow, 12, columns, false)
   t.is(wrongDrugTypeResult.length, 1)
@@ -386,7 +386,7 @@ test("validateRow tall", (t) => {
     wrongDrugTypeResult[0].message,
     '"drug_type_of_measurement" value "KG" is not one of the allowed valid values. You must encode one of these valid values: GR, ME, ML, UN, F2, EA, GM'
   )
-  t.assert(wrongDrugTypeResult[0].warning === !enforce2025)
+  t.assert(wrongDrugTypeResult[0].warning === (enforce2025 ? undefined : true))
   // standard_charge | gross must be positive number if present
   const emptyGrossRow = { ...basicRow, "standard_charge | gross": "" }
   const emptyGrossResult = validateRow(emptyGrossRow, 13, columns, false)

--- a/test/2.0/json.spec.ts
+++ b/test/2.0/json.spec.ts
@@ -218,13 +218,13 @@ test("validateJson estimated amount conditional", async (t) => {
       path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: "must have required property 'estimated_amount'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
       field: "3",
       message: 'must match "then" schema',
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
 })
@@ -242,15 +242,35 @@ test("validateJson NDC drug information conditional", async (t) => {
       path: "/standard_charge_information/0",
       field: "",
       message: "must have required property 'drug_information'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/0",
       field: "",
       message: 'must match "then" schema',
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
+})
+
+test("validateJson with incorrect code information property", async (t) => {
+  const enforce2025 = new Date().getFullYear() >= 2025
+  const result = await validateJson(
+    loadFixtureStream(
+      "/2.0/sample-conditional-error-wrong-code-information.json"
+    ),
+    "v2.0"
+  )
+  // always invalid due to missing code_information
+  t.is(result.valid, false)
+  // starting jan 1 2025, drug information is required when an NDC code is present
+  if (enforce2025) {
+    // the file contains no NDC codes, so no errors about requiring drug information should be present
+    const drugInfoError = result.errors.findIndex((err) => {
+      return err.message == "must have required property 'drug_information'"
+    })
+    t.is(drugInfoError, -1)
+  }
 })
 
 test("validateJson 2025 properties", async (t) => {
@@ -266,19 +286,19 @@ test("validateJson 2025 properties", async (t) => {
       path: "/standard_charge_information/0/drug_information",
       field: "drug_information",
       message: "must have required property 'type'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/standard_charge_information/1/standard_charges/0/payers_information/1/estimated_amount",
       field: "estimated_amount",
       message: "must be number",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
     {
       path: "/modifier_information/0",
       field: "0",
       message: "must have required property 'modifier_payer_information'",
-      warning: enforce2025 ? undefined : true,
+      ...(enforce2025 ? {} : { warning: true }),
     },
   ])
 })

--- a/test/fixtures/2.0/sample-conditional-error-wrong-code-information.json
+++ b/test/fixtures/2.0/sample-conditional-error-wrong-code-information.json
@@ -1,0 +1,195 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "hospital_location": ["West Mercy Hospital", "West Mercy Surgical Center"],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "affirmation": {
+    "affirmation": "To the best of its knowledge and belief, the hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date indicated.",
+    "confirm_affirmation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "CodeInformation": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "LOCAL"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "estimated_amount": 23145.98,
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "estimated_amount": 105.34,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The conditional schema for requiring drug information when an NDC code is present was written such that it would also be applied if the code information property was not present. Add required keywords to the conditional schema so that these superfluous errors do not appear.