### PR TITLE
Collect alerts

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -26,6 +26,7 @@ export async function validateJson(
     resolve({
       valid: false,
       errors: [{ path: "/", message: `Invalid version "${version}" supplied` }],
+      alerts: [],
     })
   })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,16 @@ export interface ValidationError {
   warning?: boolean
 }
 
+export interface ValidationAlert {
+  path: string
+  field?: string
+  message: string
+}
+
 export interface ValidationResult {
   valid: boolean
   errors: ValidationError[]
+  alerts: ValidationAlert[]
 }
 
 export interface CsvValidationError {
@@ -22,6 +29,13 @@ export interface CsvValidationError {
   field?: string
   message: string
   warning?: boolean
+}
+
+export interface CsvAlert {
+  row: number
+  column: number
+  field: string
+  message: string
 }
 
 /**
@@ -39,6 +53,12 @@ export interface CsvValidatorVersion {
     columns: string[],
     wide: boolean
   ) => CsvValidationError[]
+  collectAlerts: (
+    row: { [key: string]: string },
+    index: number,
+    columns: string[],
+    wide: boolean
+  ) => CsvAlert[]
   isTall: (columns: string[]) => boolean
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,20 @@ export function addErrorsToList<T extends { warning?: boolean | undefined }>(
       }
     })
   }
+  return counts
+}
 
+export function addAlertsToList<T>(
+  newAlerts: T[],
+  alertList: T[],
+  maxAlerts = 0,
+  counts: { alerts: number }
+) {
+  if (maxAlerts > 0 && counts.alerts + newAlerts.length > maxAlerts) {
+    newAlerts = newAlerts.slice(0, maxAlerts - counts.alerts)
+  }
+  alertList.push(...newAlerts)
+  counts.alerts = alertList.length
   return counts
 }
 

--- a/src/versions/1.1/csv.ts
+++ b/src/versions/1.1/csv.ts
@@ -569,4 +569,5 @@ export const CsvValidatorOneOne = {
   validateColumns,
   validateRow,
   isTall,
+  collectAlerts: () => [],
 }

--- a/src/versions/1.1/json.ts
+++ b/src/versions/1.1/json.ts
@@ -229,6 +229,7 @@ export async function validateJson(
           resolve({
             valid: false,
             errors: errors.slice(0, options.maxErrors),
+            alerts: [],
           })
           parser.end()
         }
@@ -256,6 +257,7 @@ export async function validateJson(
           options.maxErrors && options.maxErrors > 0
             ? errors.slice(0, options.maxErrors)
             : errors,
+        alerts: [],
       })
     }
 

--- a/test/fixtures/2.0/sample-nine-nines.json
+++ b/test/fixtures/2.0/sample-nine-nines.json
@@ -1,0 +1,195 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "hospital_location": ["West Mercy Hospital", "West Mercy Surgical Center"],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "affirmation": {
+    "affirmation": "To the best of its knowledge and belief, the hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date indicated.",
+    "confirm_affirmation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "LOCAL"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "estimated_amount": 22243.34,
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "estimated_amount": 999999999,
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "estimated_amount": 999999999.0,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When validating, collect alerts in addition to errors. The maximum for errors also applies to alerts. If the amount of alerts reaches the maximum, validation will continue. The only alert currently implemented is for the presence of a value of `999999999` for estimated amounts. The validate methods return the list of alerts alongside the list of errors.