### PR TITLE
Move to @cmsgov namespace, update publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,21 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "19.x"
           registry-url: "https://registry.npmjs.org"
 
+      - run: npm install -g npm@9.9.4
+
       - run: npm ci
 
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_CONFIG_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hospital Price Transparency Validator
 
+[![Version](https://img.shields.io/npm/v/@cmsgov/hpt-validator)](https://www.npmjs.com/package/@cmsgov/hpt-validator)
+
 Validation library for CMS Hospital Price Transparency machine-readable files
 
 ## Resources
@@ -13,7 +15,7 @@ Validation library for CMS Hospital Price Transparency machine-readable files
 ### Installation
 
 ```
-npm install hpt-validator
+npm install @cmsgov/hpt-validator
 ```
 
 ### Testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hpt-validator",
+  "name": "@cmsgov/hpt-validator",
   "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hpt-validator",
+      "name": "@cmsgov/hpt-validator",
       "version": "1.11.1",
       "license": "CC0-1.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CMSGov/hpt-validator.git"
+    "url": "git+https://github.com/CMSgov/hpt-validator.git"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hpt-validator",
+  "name": "@cmsgov/hpt-validator",
   "version": "1.11.1",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
@@ -7,6 +7,10 @@
   "type": "module",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CMSGov/hpt-validator.git"
+  },
   "exports": {
     ".": {
       "require": "./lib/index.js",


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Rename to be in `@cmsgov` namespace, update publishing

## Problem

We're trying to consolidate CMS NPM publishing under a common namespace for clarity and general organizational management. More information about ownership increases confidence in the general supply chain and long-term maintenance

## Solution

Renames the package `@cmsgov/hpt-validator`, adds [provenance statements](https://docs.npmjs.com/generating-provenance-statements) that we're able to use of package contents because we're publishing on GitHub Actions, and updates metadata to pull this information in more directly.

The current auth token should work for this without needing to be updated since the account it's associated with now has access to publish to the organization.

## Notes

Once this is done, I can open PRs against the other two repos importing this and add a deprecation notice to the package with the older name. This won't impact current users of the package, and from a quick scan it looks like only internal projects are currently importing this.