### PR TITLE
Fix remove BOM

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,14 +47,22 @@ export function addAlertsToList<T>(
 
 export function removeBOM(chunk: string): string {
   // strip utf-8 BOM: see https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
-  const dataBuffer = Buffer.from(chunk)
-  if (
-    dataBuffer.length > 2 &&
-    dataBuffer[0] === 0xef &&
-    dataBuffer[1] === 0xbb &&
-    dataBuffer[2] === 0xbf
-  ) {
-    chunk = chunk.trimStart()
+  // Handle Buffer input
+  if (Buffer.isBuffer(chunk)) {
+    // Check for BOM in buffer
+    if (chunk.length > 2 && chunk[0] === 0xef && chunk[1] === 0xbb && chunk[2] === 0xbf) {
+      // Return buffer without BOM
+      return chunk.slice(3);
+    }
+
+    return chunk;
   }
-  return chunk
+
+  // Check for BOM in string and remove if present
+  if (typeof chunk === 'string' && chunk.charCodeAt(0) === 0xfeff) {
+    return chunk.substring(1);
+  }
+
+  // For any other type, return as is
+  return chunk;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,19 +50,24 @@ export function removeBOM(chunk: string): string {
   // Handle Buffer input
   if (Buffer.isBuffer(chunk)) {
     // Check for BOM in buffer
-    if (chunk.length > 2 && chunk[0] === 0xef && chunk[1] === 0xbb && chunk[2] === 0xbf) {
+    if (
+      chunk.length > 2 &&
+      chunk[0] === 0xef &&
+      chunk[1] === 0xbb &&
+      chunk[2] === 0xbf
+    ) {
       // Return buffer without BOM
-      return chunk.slice(3);
+      return chunk.slice(3)
     }
 
-    return chunk;
+    return chunk
   }
 
   // Check for BOM in string and remove if present
-  if (typeof chunk === 'string' && chunk.charCodeAt(0) === 0xfeff) {
-    return chunk.substring(1);
+  if (typeof chunk === "string" && chunk.charCodeAt(0) === 0xfeff) {
+    return chunk.substring(1)
   }
 
   // For any other type, return as is
-  return chunk;
+  return chunk
 }


### PR DESCRIPTION
Fixes issues with `removeBOM` to properly handle UTF-8 BOM.

## Problem

The current implementation of `removeBOM()` in `utils.js` has critical issues:

1. It correctly detects the UTF-8 BOM (0xEF 0xBB 0xBF) but doesn't actually remove it
2. `trimStart()` removes whitespace rather than removing the BOM bytes
3. It creates unnecessary buffer copies with Buffer.from(chunk) even for inputs that are already Buffers
4. It doesn't handle string inputs with BOM characters (Unicode BOM 0xFEFF)
6. These issues can lead to improper file processing when files contain BOM markers, potentially causing validation errors and unexpected behavior in downstream processes.


## Solution

The updated implementation:

1. Uses proper type checking with `Buffer.isBuffer()` to avoid unnecessary conversions
2. Correctly removes the UTF-8 BOM from buffer inputs using `slice(3)` which removes the BOM characters instead of whitespace
3. Properly handles string inputs with BOM characters using `charCodeAt(0) === 0xfeff`
4. Removes the whitespace trimming functionality, which was unrelated to BOM removal

## Result

This ensures that files with BOMs are correctly processed by the validator, which prevents validation errors and inconsistencies in the processing pipeline.

Our use case is that we're streaming files from a S3 bucket to a Lambda to validate them. We found some specific files that would fail with the error below. But if we downloaded the file and used the CLI or online validator the file validated without issue. These updates fix this S3 streaming issue and allow the validator to function properly.

## Test Plan

We noticed this issue with this MRF: https://smmcnj.com/wp-content/uploads/2024/12/1568825545_SaintMichaelsMedicalCenter_standardcharges.json

That MRF has been tested and verified. I initially made these updates our code base back in June. We've tested around 200 MRFs since then and have seen no issues.
