### PR TITLE
Error for no code pairs applies to row

### DIFF
--- a/src/versions/2.0/csv.ts
+++ b/src/versions/2.0/csv.ts
@@ -385,9 +385,7 @@ export function validateRow(
   }
 
   if (!foundCode) {
-    errors.push(
-      csvErr(index, columns.length, "code | 1", ERRORS.CODE_ONE_REQUIRED())
-    )
+    errors.push(csvErr(index, -1, "code | 1", ERRORS.CODE_ONE_REQUIRED()))
   }
 
   errors.push(

--- a/test/2.0/csv.spec.ts
+++ b/test/2.0/csv.spec.ts
@@ -466,7 +466,7 @@ test("validateRow tall", (t) => {
     wrongMaxResult[0].message,
     '"standard_charge | max" value "-2" is not a positive number. You must encode a positive, non-zero, numeric value.'
   )
-  // no code pairs is invalid
+  // no code pairs is invalid. the error applies to the row
   const noCodesRow = { ...basicRow, "code | 1": "", "code | 1 | type": "" }
   const noCodesResult = validateRow(noCodesRow, 21, columns, false)
   t.is(noCodesResult.length, 1)
@@ -474,6 +474,7 @@ test("validateRow tall", (t) => {
     noCodesResult[0].message,
     "If a standard charge is encoded, there must be a corresponding code and code type pairing. The code and code type pairing do not need to be in the first code and code type columns (i.e., code|1 and code|1|type)."
   )
+  t.is(noCodesResult[0].column, -1)
   // a code pair not in the first column is valid
   const secondCodeRow = {
     ...basicRow,


### PR DESCRIPTION
When creating an error for a row that has no code pairs, set the column for the error to -1 to indicate that the error exists at the row level, rather than at a particular cell.

Addresses https://github.com/CMSgov/hospital-price-transparency/issues/173.