### PR TITLE
Handle non-required header columns

### DIFF
--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -1148,14 +1148,14 @@ export class CsvValidator extends BaseValidator {
   alertHeaderRow(row: string[]): csvErr.CsvValidationError[] {
     if (semver.satisfies(this.version, ">=3.0.0")) {
       const statementIndex = this.headerColumns.findIndex((headerCol) =>
-        matchesString(headerCol, ATTESTATION)
+        matchesString(headerCol ?? "", ATTESTATION)
       );
       if (statementIndex > -1 && matchesString(row[statementIndex], "false")) {
         return [new CsvFalseAttestationAlert(statementIndex)];
       }
     } else if (semver.satisfies(this.version, "2.*")) {
       const statementIndex = this.headerColumns.findIndex((headerCol) =>
-        matchesString(headerCol, AFFIRMATION)
+        matchesString(headerCol ?? "", AFFIRMATION)
       );
       if (statementIndex > -1 && matchesString(row[statementIndex], "false")) {
         return [new CsvFalseAffirmationAlert(statementIndex)];

--- a/test/validators/CsvValidator.v2.0.0.test.ts
+++ b/test/validators/CsvValidator.v2.0.0.test.ts
@@ -52,6 +52,24 @@ describe("schema v2.0.0", () => {
       );
     });
 
+    it("should return no errors when a non-required header column is present, but not include it in the stored header columns", () => {
+      const columns = shuffle([
+        "hospital_name",
+        "last_updated_on",
+        "version",
+        "hospital_location",
+        "hospital_address",
+        "license_number | MD",
+        AFFIRMATION,
+      ]);
+      columns.splice(2, 0, "financial_aid_policy");
+      const result = validator.validateHeaderColumns(columns);
+      expect(result).toHaveLength(0);
+      const expectedColumns = [...columns];
+      delete expectedColumns[2];
+      expect(validator.headerColumns).toEqual(expectedColumns);
+    });
+
     it("should return errors and remove duplicates when a header column appears more than once", () => {
       const columns = [
         "hospital_name",
@@ -286,6 +304,31 @@ describe("schema v2.0.0", () => {
         "123 Address",
         "001 | MD",
         "I agree",
+      ]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should handle a case when a header column is blank", () => {
+      validator.headerColumns = [
+        "hospital_name",
+        "last_updated_on",
+        "delete_this_one",
+        "version",
+        "hospital_location",
+        "hospital_address",
+        "license_number | MD",
+        AFFIRMATION,
+      ];
+      delete validator.headerColumns[2];
+      const result = validator.alertHeaderRow([
+        "name",
+        "2022-01-01",
+        "",
+        "1.0.0",
+        "Woodlawn",
+        "123 Address",
+        "001 | MD",
+        "true",
       ]);
       expect(result).toHaveLength(0);
     });

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -158,6 +158,35 @@ describe("CsvValidator v3.0.0", () => {
       ]);
       expect(result).toHaveLength(0);
     });
+
+    it("should handle a case where a header column is blank", () => {
+      validator.headerColumns = [
+        "hospital_name",
+        "last_updated_on",
+        "version",
+        "location_name",
+        "this_one_is_deleted",
+        "hospital_address",
+        "license_number | MD",
+        ATTESTATION,
+        "attester_name",
+        "type_2_npi",
+      ];
+      delete validator.headerColumns[4];
+      const result = validator.alertHeaderRow([
+        "name",
+        "2022-01-01",
+        "1.0.0",
+        "Woodlawn",
+        "",
+        "123 Address",
+        "001 | MD",
+        "true",
+        "Alex Attester",
+        "1122334455",
+      ]);
+      expect(result).toHaveLength(0);
+    });
   });
 
   describe("#validateColumns", () => {


### PR DESCRIPTION
Row 1 of a CSV may contain non-required header columns. This results in empty elements in the CsvValidator.headerColumns array. When iterating over this array, handle empty elements by treating them as empty strings.