### PR TITLE
Normalize payer plan to be all lowercase

### DIFF
--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -1389,7 +1389,9 @@ export class CsvValidator extends BaseValidator {
             "methodology",
           ].some((p) => matchesString(p, splitColumn[3]))
         ) {
-          payersPlans.add(splitColumn.slice(1, 3).join(" | "));
+          payersPlans.add(
+            splitColumn.slice(1, 3).join(" | ").toLocaleLowerCase()
+          );
         }
       } else if (splitColumn.length === 3) {
         const otherPossibilities = ["additional_payer_notes"];
@@ -1404,7 +1406,9 @@ export class CsvValidator extends BaseValidator {
           );
         }
         if (otherPossibilities.some((p) => matchesString(p, splitColumn[0]))) {
-          payersPlans.add(splitColumn.slice(1, 3).join(" | "));
+          payersPlans.add(
+            splitColumn.slice(1, 3).join(" | ").toLocaleLowerCase()
+          );
         }
       }
     });

--- a/test/validators/CsvValidator.v2.1.0.test.ts
+++ b/test/validators/CsvValidator.v2.1.0.test.ts
@@ -330,11 +330,11 @@ describe("CsvValidator v2.1.0", () => {
         "standard_charge | discounted_cash",
         "standard_charge | min",
         "standard_charge | max",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
-        "standard_charge | Payer ABC | Plan 1 | methodology",
-        "additional_payer_notes | Payer ABC | Plan 1",
+        "standard_charge | payer abc | plan 1 | negotiated_dollar",
+        "standard_charge | payer abc | plan 1 | negotiated_percentage",
+        "standard_charge | payer abc | plan 1 | negotiated_algorithm",
+        "standard_charge | payer abc | plan 1 | methodology",
+        "additional_payer_notes | payer abc | plan 1",
         "additional_generic_notes",
       ]);
     });
@@ -428,21 +428,21 @@ describe("CsvValidator v2.1.0", () => {
       expect(result).toHaveLength(4);
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_dollar"
+          "standard_charge | payer abc | plan 1 | negotiated_dollar"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_percentage"
+          "standard_charge | payer abc | plan 1 | negotiated_percentage"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"
+          "standard_charge | payer abc | plan 1 | negotiated_algorithm"
         )
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("additional_payer_notes | Payer ABC | Plan 1")
+        new ColumnMissingError("additional_payer_notes | payer abc | plan 1")
       );
     });
   });
@@ -885,16 +885,16 @@ describe("CsvValidator v2.1.0", () => {
       "standard_charge | discounted_cash",
       "standard_charge | min",
       "standard_charge | max",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
-      "standard_charge | Payer ABC | Plan 1 | methodology",
-      "additional_payer_notes | Payer ABC | Plan 1",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_dollar",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_percentage",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm",
-      "standard_charge | Payer XYZ | Plan 2 | methodology",
-      "additional_payer_notes | Payer XYZ | Plan 2",
+      "standard_charge | payer abc | plan 1 | negotiated_dollar",
+      "standard_charge | payer abc | plan 1 | negotiated_percentage",
+      "standard_charge | payer abc | plan 1 | negotiated_algorithm",
+      "standard_charge | payer abc | plan 1 | methodology",
+      "additional_payer_notes | payer abc | plan 1",
+      "standard_charge | payer xyz | plan 2 | negotiated_dollar",
+      "standard_charge | payer xyz | plan 2 | negotiated_percentage",
+      "standard_charge | payer xyz | plan 2 | negotiated_algorithm",
+      "standard_charge | payer xyz | plan 2 | methodology",
+      "additional_payer_notes | payer xyz | plan 2",
       "additional_generic_notes",
     ];
     let row: { [key: string]: string } = {};
@@ -920,16 +920,16 @@ describe("CsvValidator v2.1.0", () => {
         "standard_charge | discounted_cash": "",
         "standard_charge | min": "",
         "standard_charge | max": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm": "",
-        "standard_charge | Payer ABC | Plan 1 | methodology": "",
-        "additional_payer_notes | Payer ABC | Plan 1": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_dollar": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_percentage": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm": "",
-        "standard_charge | Payer XYZ | Plan 2 | methodology": "",
-        "additional_payer_notes | Payer XYZ | Plan 2": "",
+        "standard_charge | payer abc | plan 1 | negotiated_dollar": "",
+        "standard_charge | payer abc | plan 1 | negotiated_percentage": "",
+        "standard_charge | payer abc | plan 1 | negotiated_algorithm": "",
+        "standard_charge | payer abc | plan 1 | methodology": "",
+        "additional_payer_notes | payer abc | plan 1": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_dollar": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_percentage": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_algorithm": "",
+        "standard_charge | payer xyz | plan 2 | methodology": "",
+        "additional_payer_notes | payer xyz | plan 2": "",
         additional_generic_notes: "",
       };
     });
@@ -943,8 +943,8 @@ describe("CsvValidator v2.1.0", () => {
     // then a corresponding valid value for the payer name, plan name, and standard charge methodology must also be encoded.
     // Since the wide format incorporates payer name and plan name into the column name, only methodology is checked.
     it("should return no errors when a payer specific negotiated charge is a dollar amount and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "500";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "500";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
       row["standard_charge | min"] = "500";
       row["standard_charge | max"] = "500";
@@ -953,7 +953,7 @@ describe("CsvValidator v2.1.0", () => {
     });
 
     it("should return errors when a payer specific negotiated charge is a dollar amount, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "500";
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "500";
       row["standard_charge | min"] = "500";
       row["standard_charge | max"] = "500";
       const result = validator.validateDataRow(row);
@@ -969,16 +969,16 @@ describe("CsvValidator v2.1.0", () => {
     });
 
     it("should return no errors when a payer specific negotiated charge is a percentage and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "60";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "percent of total billed charges";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return errors when a payer specific negotiated charge is a percentage, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "60";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
@@ -993,16 +993,16 @@ describe("CsvValidator v2.1.0", () => {
     });
 
     it("should return no errors when a payer specific negotiated charge is an algorithm and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "standard algorithm function";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return errors when a payer specific negotiated charge is an algorithm, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "standard algorithm function";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
@@ -1019,19 +1019,19 @@ describe("CsvValidator v2.1.0", () => {
     // If the "standard charge methodology" encoded value is "other", there must be a corresponding explanation found
     // in the "additional notes" for the associated payer-specific negotiated charge.
     it("should return no errors when a methodology is 'other' and payer-specific notes are provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
-      row["additional_payer_notes | Payer XYZ | Plan 2"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
+      row["additional_payer_notes | payer xyz | plan 2"] =
         "explanation of the complicated formula.";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return an error when a methodology is 'other' and payer-specific notes are not provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1040,10 +1040,10 @@ describe("CsvValidator v2.1.0", () => {
     });
 
     it("should return an error when a methodology is 'other' and payer-specific notes are provided for a different payer and plan", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
-      row["additional_payer_notes | Payer ABC | Plan 1"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
+      row["additional_payer_notes | payer abc | plan 1"] =
         "these notes are for the wrong payer and plan.";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
@@ -1075,8 +1075,8 @@ describe("CsvValidator v2.1.0", () => {
 
     it("should return no errors when an item or service with only a payer-specific dollar amount", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "3800";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "3800";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
       row["standard_charge | min"] = "3800";
       row["standard_charge | max"] = "3800";
@@ -1086,18 +1086,18 @@ describe("CsvValidator v2.1.0", () => {
 
     it("should return no errors when an item or service with only a payer-specific percentage", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when an item or service with only a payer-specific algorithm", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
@@ -1105,8 +1105,8 @@ describe("CsvValidator v2.1.0", () => {
     // If there is a "payer specific negotiated charge" encoded as a dollar amount,
     // there must be a corresponding valid value encoded for the deidentified minimum and deidentified maximum negotiated charge data.
     it("should return an error when a payer-specific dollar amount is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "740";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "740";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1115,17 +1115,17 @@ describe("CsvValidator v2.1.0", () => {
     });
 
     it("should return no errors when a payer-specific percentage is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when a payer-specific algorithm is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });

--- a/test/validators/CsvValidator.v2.2.0.test.ts
+++ b/test/validators/CsvValidator.v2.2.0.test.ts
@@ -275,6 +275,67 @@ describe("CsvValidator v2.2.0", () => {
     });
   });
 
+  describe("#getPayersPlans", () => {
+    it("should get no payers and plans for a set of tall-format columns", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge   | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "additional_generic_notes",
+        "payer_name",
+        "plan_name",
+        "standard_charge | negotiated_dollar",
+        "standard_charge | negotiated_percentage",
+        "standard_charge | negotiated_algorithm",
+        "standard_charge | methodology",
+        "estimated_amount",
+      ]);
+      const payersPlans = validator.getPayersPlans(columns);
+      expect(payersPlans).toHaveLength(0);
+    });
+
+    it("should get the payers and plans for a set of wide-format columns, regardless of payer or plan capitalization", () => {
+      const columns = [
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer abc | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | PLAN 1 | negotiated_algorithm",
+        "standard_charge | PAYER ABC | Plan 1 | methodology",
+        "estimated_amount |  Payer ABC | Plan 1",
+        "additional_payer_notes | payer abc | Plan 1",
+        "standard_charge | other payer | good plan | negotiated_dollar",
+        "standard_charge | Other payer | Good plan | negotiated_percentage",
+        "standard_charge | other payer | GOOD plan | negotiated_algorithm",
+        "standard_charge | other Payer | good plan | methodology",
+        "estimated_amount |  other payer | good plan",
+        "additional_payer_notes | other payer | good plan",
+        "additional_generic_notes",
+      ];
+      const payersPlans = validator.getPayersPlans(columns);
+      expect(payersPlans).toHaveLength(2);
+      expect(payersPlans).toContain("payer abc | plan 1");
+      expect(payersPlans).toContain("other payer | good plan");
+    });
+  });
+
   describe("#validateColumns", () => {
     it("should return no errors when valid tall columns are provided", () => {
       // order of the columns does not matter
@@ -372,12 +433,12 @@ describe("CsvValidator v2.2.0", () => {
         "standard_charge | discounted_cash",
         "standard_charge | min",
         "standard_charge | max",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
-        "standard_charge | Payer ABC | Plan 1 | methodology",
-        "estimated_amount | Payer ABC | Plan 1",
-        "additional_payer_notes | Payer ABC | Plan 1",
+        "standard_charge | payer abc | plan 1 | negotiated_dollar",
+        "standard_charge | payer abc | plan 1 | negotiated_percentage",
+        "standard_charge | payer abc | plan 1 | negotiated_algorithm",
+        "standard_charge | payer abc | plan 1 | methodology",
+        "estimated_amount | payer abc | plan 1",
+        "additional_payer_notes | payer abc | plan 1",
         "additional_generic_notes",
       ]);
     });
@@ -613,24 +674,24 @@ describe("CsvValidator v2.2.0", () => {
       expect(result).toHaveLength(5);
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_dollar"
+          "standard_charge | payer abc | plan 1 | negotiated_dollar"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_percentage"
+          "standard_charge | payer abc | plan 1 | negotiated_percentage"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"
+          "standard_charge | payer abc | plan 1 | negotiated_algorithm"
         )
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("estimated_amount | Payer ABC | Plan 1")
+        new ColumnMissingError("estimated_amount | payer abc | plan 1")
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("additional_payer_notes | Payer ABC | Plan 1")
+        new ColumnMissingError("additional_payer_notes | payer abc | plan 1")
       );
     });
 
@@ -1427,18 +1488,18 @@ describe("CsvValidator v2.2.0", () => {
       "standard_charge | discounted_cash",
       "standard_charge | min",
       "standard_charge | max",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
-      "standard_charge | Payer ABC | Plan 1 | methodology",
-      "estimated_amount | Payer ABC | Plan 1",
-      "additional_payer_notes | Payer ABC | Plan 1",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_dollar",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_percentage",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm",
-      "standard_charge | Payer XYZ | Plan 2 | methodology",
-      "estimated_amount | Payer XYZ | Plan 2",
-      "additional_payer_notes | Payer XYZ | Plan 2",
+      "standard_charge | payer abc | plan 1 | negotiated_dollar",
+      "standard_charge | payer abc | plan 1 | negotiated_percentage",
+      "standard_charge | payer abc | plan 1 | negotiated_algorithm",
+      "standard_charge | payer abc | plan 1 | methodology",
+      "estimated_amount | payer abc | plan 1",
+      "additional_payer_notes | payer abc | plan 1",
+      "standard_charge | payer xyz | plan 2 | negotiated_dollar",
+      "standard_charge | payer xyz | plan 2 | negotiated_percentage",
+      "standard_charge | payer xyz | plan 2 | negotiated_algorithm",
+      "standard_charge | payer xyz | plan 2 | methodology",
+      "estimated_amount | payer xyz | plan 2",
+      "additional_payer_notes | payer xyz | plan 2",
       "additional_generic_notes",
     ];
     let row: { [key: string]: string } = {};
@@ -1467,18 +1528,18 @@ describe("CsvValidator v2.2.0", () => {
         "standard_charge | discounted_cash": "",
         "standard_charge | min": "",
         "standard_charge | max": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage": "",
-        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm": "",
-        "standard_charge | Payer ABC | Plan 1 | methodology": "",
-        "estimated_amount | Payer ABC | Plan 1": "",
-        "additional_payer_notes | Payer ABC | Plan 1": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_dollar": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_percentage": "",
-        "standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm": "",
-        "standard_charge | Payer XYZ | Plan 2 | methodology": "",
-        "estimated_amount | Payer XYZ | Plan 2": "",
-        "additional_payer_notes | Payer XYZ | Plan 2": "",
+        "standard_charge | payer abc | plan 1 | negotiated_dollar": "",
+        "standard_charge | payer abc | plan 1 | negotiated_percentage": "",
+        "standard_charge | payer abc | plan 1 | negotiated_algorithm": "",
+        "standard_charge | payer abc | plan 1 | methodology": "",
+        "estimated_amount | payer abc | plan 1": "",
+        "additional_payer_notes | payer abc | plan 1": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_dollar": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_percentage": "",
+        "standard_charge | payer xyz | plan 2 | negotiated_algorithm": "",
+        "standard_charge | payer xyz | plan 2 | methodology": "",
+        "estimated_amount | payer xyz | plan 2": "",
+        "additional_payer_notes | payer xyz | plan 2": "",
         additional_generic_notes: "",
       };
     });
@@ -1489,13 +1550,13 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return an error when estimated amount is present, but not a positive number", () => {
-      row["estimated_amount | Payer ABC | Plan 1"] = "Unknown";
+      row["estimated_amount | payer abc | plan 1"] = "Unknown";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new InvalidPositiveNumberError(
           validator.index,
-          normalizedColumns.indexOf("estimated_amount | Payer ABC | Plan 1"),
+          normalizedColumns.indexOf("estimated_amount | payer abc | plan 1"),
           "estimated_amount |  Payer ABC | Plan 1",
           "Unknown"
         )
@@ -1506,8 +1567,8 @@ describe("CsvValidator v2.2.0", () => {
     // then a corresponding valid value for the payer name, plan name, and standard charge methodology must also be encoded.
     // Since the wide format incorporates payer name and plan name into the column name, only methodology is checked.
     it("should return no errors when a payer specific negotiated charge is a dollar amount and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "500";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "500";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
       row["standard_charge | min"] = "500";
       row["standard_charge | max"] = "500";
@@ -1516,7 +1577,7 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return errors when a payer specific negotiated charge is a dollar amount, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "500";
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "500";
       row["standard_charge | min"] = "500";
       row["standard_charge | max"] = "500";
       const result = validator.validateDataRow(row);
@@ -1532,19 +1593,19 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return no errors when a payer specific negotiated charge is a percentage and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "60";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "percent of total billed charges";
-      row["estimated_amount | Payer ABC | Plan 1"] = "5065";
+      row["estimated_amount | payer abc | plan 1"] = "5065";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return errors when a payer specific negotiated charge is a percentage, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "60";
-      row["estimated_amount | Payer ABC | Plan 1"] = "525";
+      row["estimated_amount | payer abc | plan 1"] = "525";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1558,19 +1619,19 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return no errors when a payer specific negotiated charge is an algorithm and a valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "standard algorithm function";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
-      row["estimated_amount | Payer ABC | Plan 1"] = "505";
+      row["estimated_amount | payer abc | plan 1"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return errors when a payer specific negotiated charge is an algorithm, but no valid value exists for methodology", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "standard algorithm function";
-      row["estimated_amount | Payer ABC | Plan 1"] = "505";
+      row["estimated_amount | payer abc | plan 1"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1586,21 +1647,21 @@ describe("CsvValidator v2.2.0", () => {
     // If the "standard charge methodology" encoded value is "other", there must be a corresponding explanation found
     // in the "additional notes" for the associated payer-specific negotiated charge.
     it("should return no errors when a methodology is 'other' and payer-specific notes are provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "505";
-      row["additional_payer_notes | Payer XYZ | Plan 2"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
+      row["estimated_amount | payer xyz | plan 2"] = "505";
+      row["additional_payer_notes | payer xyz | plan 2"] =
         "explanation of the complicated formula.";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return an error when a methodology is 'other' and payer-specific notes are not provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "505";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
+      row["estimated_amount | payer xyz | plan 2"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1609,11 +1670,11 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return an error when a methodology is 'other' and payer-specific notes are provided for a different payer and plan", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "a complicated formula";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "other";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "505";
-      row["additional_payer_notes | Payer ABC | Plan 1"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "other";
+      row["estimated_amount | payer xyz | plan 2"] = "505";
+      row["additional_payer_notes | payer abc | plan 1"] =
         "these notes are for the wrong payer and plan.";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
@@ -1645,8 +1706,8 @@ describe("CsvValidator v2.2.0", () => {
 
     it("should return no errors when an item or service with only a payer-specific dollar amount", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "3800";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "3800";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
       row["standard_charge | min"] = "3800";
       row["standard_charge | max"] = "3800";
@@ -1656,20 +1717,20 @@ describe("CsvValidator v2.2.0", () => {
 
     it("should return no errors when an item or service with only a payer-specific percentage", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "9500";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
+      row["estimated_amount | payer xyz | plan 2"] = "9500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when an item or service with only a payer-specific algorithm", () => {
       row["standard_charge | gross"] = "";
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
-      row["estimated_amount | Payer ABC | Plan 1"] = "7500";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
+      row["estimated_amount | payer abc | plan 1"] = "7500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
@@ -1677,8 +1738,8 @@ describe("CsvValidator v2.2.0", () => {
     // If there is a "payer specific negotiated charge" encoded as a dollar amount,
     // there must be a corresponding valid value encoded for the deidentified minimum and deidentified maximum negotiated charge data.
     it("should return an error when a payer-specific dollar amount is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_dollar"] = "740";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
+      row["standard_charge | payer abc | plan 1 | negotiated_dollar"] = "740";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result).toContainEqual(
@@ -1687,19 +1748,19 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return no errors when a payer-specific percentage is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "9500";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
+      row["estimated_amount | payer xyz | plan 2"] = "9500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when a payer-specific algorithm is encoded without a minimum or maximum", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
-      row["estimated_amount | Payer ABC | Plan 1"] = "7500";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
+      row["estimated_amount | payer abc | plan 1"] = "7500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
@@ -1735,7 +1796,7 @@ describe("CsvValidator v2.2.0", () => {
       row["code | 1 | type"] = "";
       row.setting = "";
       row.modifiers = "typical modifier";
-      row["additional_payer_notes | Payer ABC | Plan 1"] =
+      row["additional_payer_notes | payer abc | plan 1"] =
         "additional notes for this payer to explain modifier";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
@@ -1746,7 +1807,7 @@ describe("CsvValidator v2.2.0", () => {
       row["code | 1 | type"] = "";
       row.setting = "";
       row.modifiers = "typical modifier";
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_dollar"] = "395";
+      row["standard_charge | payer xyz | plan 2 | negotiated_dollar"] = "395";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
@@ -1756,7 +1817,7 @@ describe("CsvValidator v2.2.0", () => {
       row["code | 1 | type"] = "";
       row.setting = "";
       row.modifiers = "typical modifier";
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "150";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
@@ -1767,7 +1828,7 @@ describe("CsvValidator v2.2.0", () => {
       row["code | 1 | type"] = "";
       row.setting = "";
       row.modifiers = "typical modifier";
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "charge transformation table";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
@@ -1776,18 +1837,18 @@ describe("CsvValidator v2.2.0", () => {
     // If a "payer specific negotiated charge" can only be expressed as a percentage or algorithm,
     // then a corresponding "Estimated Allowed Amount" must also be encoded. new in v2.2.0
     it("should return no errors when a payer-specific percentage and an estimated allowed amount are provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "9500";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
+      row["estimated_amount | payer xyz | plan 2"] = "9500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return an error when a payer-specific percentage but no estimated allowed amount are provided", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
@@ -1796,18 +1857,18 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return no errors when a payer-specific algorithm and an estimated allowed amount are provided", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
-      row["estimated_amount | Payer ABC | Plan 1"] = "7500";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
+      row["estimated_amount | payer abc | plan 1"] = "7500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return an error when a payer-specific algorithm but no estimated allowed amount are provided", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
@@ -1816,10 +1877,10 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return an error when a payer-specific percentage is provided, but the estimated allowed amount is provided for a different payer and plan", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "70";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] = "case rate";
-      row["estimated_amount | Payer ABC | Plan 1"] = "7500";
+      row["standard_charge | payer xyz | plan 2 | methodology"] = "case rate";
+      row["estimated_amount | payer abc | plan 1"] = "7500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
@@ -1828,10 +1889,10 @@ describe("CsvValidator v2.2.0", () => {
     });
 
     it("should return an error when a payer-specific algorithm is provided, but the estimated allowed amount is provided for a different payer and plan", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "adjusted scale of charges";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] = "case rate";
-      row["estimated_amount | Payer XYZ | Plan 2"] = "9500";
+      row["standard_charge | payer abc | plan 1 | methodology"] = "case rate";
+      row["estimated_amount | payer xyz | plan 2"] = "9500";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
@@ -1864,7 +1925,7 @@ describe("CsvValidator v2.2.0", () => {
     // amount data element within the MRF and should instead encode an actual dollar amount.
     // new as of 2025/05/22, at which point v2.2.0 was in effect.
     it("should return an alert when 999999999 is encoded for an estimated amount", () => {
-      row["estimated_amount | Payer ABC | Plan 1"] = "999999999";
+      row["estimated_amount | payer abc | plan 1"] = "999999999";
       const result = validator.alertDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(new CsvNineNinesAlert(validator.index, 17));

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -189,6 +189,78 @@ describe("CsvValidator v3.0.0", () => {
     });
   });
 
+  describe("#getPayersPlans", () => {
+    it("should get no payers and plans for a set of tall-format columns", () => {
+      const columns = [
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge   | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "additional_generic_notes",
+        "payer_name",
+        "plan_name",
+        "standard_charge | negotiated_dollar",
+        "standard_charge | negotiated_percentage",
+        "standard_charge | negotiated_algorithm",
+        "standard_charge | methodology",
+        "median_amount",
+        "10th_percentile",
+        "90th_percentile",
+        "count",
+      ];
+      const payersPlans = validator.getPayersPlans(columns);
+      expect(payersPlans).toHaveLength(0);
+    });
+
+    it("should get the payers and plans for a set of wide-format columns, regardless of payer or plan capitalization", () => {
+      const columns = [
+        "description",
+        "setting",
+        "code | 1",
+        "code | 1 | type",
+        "code | 2",
+        "code | 2 | type",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer abc | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | PLAN 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile | Payer Abc | Plan 1",
+        "count | payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "standard_charge | Payer xyz | Plan 2 | negotiated_dollar",
+        "standard_charge | Payer XYZ | PLAN 2 | negotiated_percentage",
+        "standard_charge | PAYER XYZ | Plan 2 | negotiated_algorithm",
+        "standard_charge | Payer XYZ | Plan 2 | methodology",
+        "median_amount | Payer XYZ | plan 2",
+        "10th_percentile | Payer XYZ | Plan 2",
+        "90th_percentile | PAYER XYZ | PLAN 2",
+        "count | Payer XYZ | Plan 2",
+        "additional_payer_notes | PAYER xyz | Plan 2",
+        "additional_generic_notes",
+      ];
+      const payersPlans = validator.getPayersPlans(columns);
+      expect(payersPlans).toHaveLength(2);
+      expect(payersPlans).toContain("payer abc | plan 1");
+      expect(payersPlans).toContain("payer xyz | plan 2");
+    });
+  });
+
   describe("#validateColumns", () => {
     it("should return no errors when valid tall columns are provided", () => {
       // order of the columns does not matter
@@ -359,27 +431,27 @@ describe("CsvValidator v3.0.0", () => {
       expect(result).toHaveLength(6);
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_dollar"
+          "standard_charge | payer abc | plan 1 | negotiated_dollar"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_percentage"
+          "standard_charge | payer abc | plan 1 | negotiated_percentage"
         )
       );
       expect(result).toContainEqual(
         new ColumnMissingError(
-          "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"
+          "standard_charge | payer abc | plan 1 | negotiated_algorithm"
         )
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("median_amount | Payer ABC | Plan 1")
+        new ColumnMissingError("median_amount | payer abc | plan 1")
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("additional_payer_notes | Payer ABC | Plan 1")
+        new ColumnMissingError("additional_payer_notes | payer abc | plan 1")
       );
       expect(result).toContainEqual(
-        new ColumnMissingError("count | Payer ABC | Plan 1")
+        new ColumnMissingError("count | payer abc | plan 1")
       );
     });
   });
@@ -737,24 +809,24 @@ describe("CsvValidator v3.0.0", () => {
       "standard_charge | discounted_cash",
       "standard_charge | min",
       "standard_charge | max",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
-      "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
-      "standard_charge | Payer ABC | Plan 1 | methodology",
-      "median_amount | Payer ABC | Plan 1",
-      "10th_percentile | Payer ABC | Plan 1",
-      "90th_percentile | Payer ABC | Plan 1",
-      "count | Payer ABC | Plan 1",
-      "additional_payer_notes | Payer ABC | Plan 1",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_dollar",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_percentage",
-      "standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm",
-      "standard_charge | Payer XYZ | Plan 2 | methodology",
-      "median_amount | Payer XYZ | Plan 2",
-      "10th_percentile | Payer XYZ | Plan 2",
-      "90th_percentile | Payer XYZ | Plan 2",
-      "count | Payer XYZ | Plan 2",
-      "additional_payer_notes | Payer XYZ | Plan 2",
+      "standard_charge | payer abc | plan 1 | negotiated_dollar",
+      "standard_charge | payer abc | plan 1 | negotiated_percentage",
+      "standard_charge | payer abc | plan 1 | negotiated_algorithm",
+      "standard_charge | payer abc | plan 1 | methodology",
+      "median_amount | payer abc | plan 1",
+      "10th_percentile | payer abc | plan 1",
+      "90th_percentile | payer abc | plan 1",
+      "count | payer abc | plan 1",
+      "additional_payer_notes | payer abc | plan 1",
+      "standard_charge | payer xyz | plan 2 | negotiated_dollar",
+      "standard_charge | payer xyz | plan 2 | negotiated_percentage",
+      "standard_charge | payer xyz | plan 2 | negotiated_algorithm",
+      "standard_charge | payer xyz | plan 2 | methodology",
+      "median_amount | payer xyz | plan 2",
+      "10th_percentile | payer xyz | plan 2",
+      "90th_percentile | payer xyz | plan 2",
+      "count | payer xyz | plan 2",
+      "additional_payer_notes | payer xyz | plan 2",
       "additional_generic_notes",
     ];
     let row: { [key: string]: string } = {};
@@ -813,13 +885,13 @@ describe("CsvValidator v3.0.0", () => {
     // count of allowed amounts, median, 10th percentile, and 90th percentile are new numeric fields
     // count of allowed amounts, unlike other numeric fields, may have a value of 0
     it("should return an error when count of allowed amounts is present, but not 0 or a postive number", () => {
-      row["count | Payer XYZ | Plan 2"] = "no claims";
+      row["count | payer xyz | plan 2"] = "no claims";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new InvalidCountNumberError(
           validator.index,
-          normalizedColumns.indexOf("count | Payer XYZ | Plan 2"),
+          normalizedColumns.indexOf("count | payer xyz | plan 2"),
           "count | Payer XYZ | Plan 2",
           "no claims"
         )
@@ -827,13 +899,13 @@ describe("CsvValidator v3.0.0", () => {
     });
 
     it("should return an error when median amount is present, but not a positive number", () => {
-      row["median_amount | Payer ABC | Plan 1"] = "N/A";
+      row["median_amount | payer abc | plan 1"] = "N/A";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new InvalidPositiveNumberError(
           validator.index,
-          normalizedColumns.indexOf("median_amount | Payer ABC | Plan 1"),
+          normalizedColumns.indexOf("median_amount | payer abc | plan 1"),
           "median_amount |  Payer ABC | Plan 1",
           "N/A"
         )
@@ -841,13 +913,13 @@ describe("CsvValidator v3.0.0", () => {
     });
 
     it("should return an error when 10th percentile amount is present, but not a positive number", () => {
-      row["10th_percentile | Payer XYZ | Plan 2"] = "0";
+      row["10th_percentile | payer xyz | plan 2"] = "0";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new InvalidPositiveNumberError(
           validator.index,
-          normalizedColumns.indexOf("10th_percentile | Payer XYZ | Plan 2"),
+          normalizedColumns.indexOf("10th_percentile | payer xyz | plan 2"),
           "10th_percentile | Payer XYZ | Plan 2",
           "0"
         )
@@ -855,13 +927,13 @@ describe("CsvValidator v3.0.0", () => {
     });
 
     it("should return an error when median amount is present, but not a positive number", () => {
-      row["90th_percentile | Payer ABC | Plan 1"] = "max allowed";
+      row["90th_percentile | payer abc | plan 1"] = "max allowed";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new InvalidPositiveNumberError(
           validator.index,
-          normalizedColumns.indexOf("90th_percentile | Payer ABC | Plan 1"),
+          normalizedColumns.indexOf("90th_percentile | payer abc | plan 1"),
           "90th_percentile | Payer ABC | Plan 1",
           "max allowed"
         )
@@ -874,37 +946,37 @@ describe("CsvValidator v3.0.0", () => {
     // then corresponding "Median", "10th percentile", and "90th percentile" must also be encoded. new in v3.0.0
     // Supersedes similar requirement from v2.2.0
     it("should return no errors when a payer-specific percentage or algorithm is encoded with count of allowed amounts, median, 10th percentile, and 90th percentile", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "85";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
-      row["count | Payer ABC | Plan 1"] = "35";
-      row["median_amount | Payer ABC | Plan 1"] = "370";
-      row["10th_percentile | Payer ABC | Plan 1"] = "250";
-      row["90th_percentile | Payer ABC | Plan 1"] = "505";
+      row["count | payer abc | plan 1"] = "35";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["10th_percentile | payer abc | plan 1"] = "250";
+      row["90th_percentile | payer abc | plan 1"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when a payer-specific percentage or algorithm is encoded with count of allowed amounts of 0 and additional notes", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "An Algorithm";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] =
         "fee schedule";
-      row["count | Payer XYZ | Plan 2"] = "0";
-      row["additional_payer_notes | Payer XYZ | Plan 2"] =
+      row["count | payer xyz | plan 2"] = "0";
+      row["additional_payer_notes | payer xyz | plan 2"] =
         "sufficient explanation";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(0);
     });
 
     it("should return no errors when a payer-specific percentage or algorithm is encoded with count of allowed amounts of 0 and no additional notes", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "An Algorithm";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] =
         "fee schedule";
-      row["count | Payer XYZ | Plan 2"] = "0";
-      row["additional_payer_notes | Payer XYZ | Plan 2"] = "";
+      row["count | payer xyz | plan 2"] = "0";
+      row["additional_payer_notes | payer xyz | plan 2"] = "";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
@@ -913,73 +985,73 @@ describe("CsvValidator v3.0.0", () => {
     });
 
     it("should return an error when a payer-specific percentage or algorithm is encoded without count of allowed amounts", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_percentage"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
         "85";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
-      row["median_amount | Payer ABC | Plan 1"] = "370";
-      row["10th_percentile | Payer ABC | Plan 1"] = "250";
-      row["90th_percentile | Payer ABC | Plan 1"] = "505";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["10th_percentile | payer abc | plan 1"] = "250";
+      row["90th_percentile | payer abc | plan 1"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new PercentageAlgorithmCountError(
           validator.index,
-          normalizedColumns.indexOf("count | Payer ABC | Plan 1")
+          normalizedColumns.indexOf("count | payer abc | plan 1")
         )
       );
     });
 
     it("should return an error when a payer-specific percentage or algorithm is encoded with nonzero count and without median", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_algorithm"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_algorithm"] =
         "An Algorithm";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] =
         "fee schedule";
-      row["count | Payer XYZ | Plan 2"] = "573";
-      row["10th_percentile | Payer XYZ | Plan 2"] = "250";
-      row["90th_percentile | Payer XYZ | Plan 2"] = "505";
+      row["count | payer xyz | plan 2"] = "573";
+      row["10th_percentile | payer xyz | plan 2"] = "250";
+      row["90th_percentile | payer xyz | plan 2"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new PercentageAlgorithmMedianError(
           validator.index,
-          normalizedColumns.indexOf("median_amount | Payer XYZ | Plan 2")
+          normalizedColumns.indexOf("median_amount | payer xyz | plan 2")
         )
       );
     });
 
     it("should return an error when a payer-specific percentage or algorithm is encoded with nonzero count and without 10th percentile", () => {
-      row["standard_charge | Payer ABC | Plan 1 | negotiated_algorithm"] =
+      row["standard_charge | payer abc | plan 1 | negotiated_algorithm"] =
         "standard rate formula that we keep secret";
-      row["standard_charge | Payer ABC | Plan 1 | methodology"] =
+      row["standard_charge | payer abc | plan 1 | methodology"] =
         "fee schedule";
-      row["count | Payer ABC | Plan 1"] = "250";
-      row["median_amount | Payer ABC | Plan 1"] = "370";
-      row["90th_percentile | Payer ABC | Plan 1"] = "505";
+      row["count | payer abc | plan 1"] = "250";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["90th_percentile | payer abc | plan 1"] = "505";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new PercentageAlgorithm10thError(
           validator.index,
-          normalizedColumns.indexOf("10th_percentile | Payer ABC | Plan 1")
+          normalizedColumns.indexOf("10th_percentile | payer abc | plan 1")
         )
       );
     });
 
     it("should return an error when a payer-specific percentage or algorithm is encoded with nonzero count and without 90th percentile", () => {
-      row["standard_charge | Payer XYZ | Plan 2 | negotiated_percentage"] =
+      row["standard_charge | payer xyz | plan 2 | negotiated_percentage"] =
         "85";
-      row["standard_charge | Payer XYZ | Plan 2 | methodology"] =
+      row["standard_charge | payer xyz | plan 2 | methodology"] =
         "fee schedule";
-      row["count | Payer XYZ | Plan 2"] = "573";
-      row["median_amount | Payer XYZ | Plan 2"] = "505";
-      row["10th_percentile | Payer XYZ | Plan 2"] = "250";
+      row["count | payer xyz | plan 2"] = "573";
+      row["median_amount | payer xyz | plan 2"] = "505";
+      row["10th_percentile | payer xyz | plan 2"] = "250";
       const result = validator.validateDataRow(row);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(
         new PercentageAlgorithm90thError(
           validator.index,
-          normalizedColumns.indexOf("90th_percentile | Payer XYZ | Plan 2")
+          normalizedColumns.indexOf("90th_percentile | payer xyz | plan 2")
         )
       );
     });


### PR DESCRIPTION
## Normalize payer and plan in column definitions to be all lowercase

## Problem

When validating the columns of a CSV wide file, differences in capitalization in payer or plan name will result in different payers and plans being defined for each variation. For example, `standard_charge | Payer ABC | PPO | negotiated_dollar` and `standard_charge | Payer ABC | Ppo | negotiated_percentage` would defined two different payer-plans. This means that two sets of columns would be expected to match that payer-plan, typically resulting in errors from failing to find those columns.

## Solution

When detecting the set of payers and plans present in CSV wide columns, make the string lowercase before adding it to the set. 

## Result

Payer-plan combinations that only differ by capitalization will only appear once in the set of payer-plans. CSV wide files that have variation in capitalization of payer-plan names in columns may now pass the validator. Since the list of expected columns no longer preserves case of payer-plan names, error messages for missing columns will now show all-lowercase payer-plan names, regardless of original capitalization.

## Test Plan

Add tests that explicitly check the results of `CsvValidator.getPayersPlans` in cases where capitalization of payers and plans vary. Since the expected columns vary based on specified data dictionary version, add tests for different data dictionary versions. Update existing tests that check `CsvValidator.normalizedColumns` to reflect that the normalized column names for columns that include payer-plans no longer preserve capitalization.