### PR TITLE
Detect unreplaced placeholders

### DIFF
--- a/src/errors/csv/PlaceholderError.ts
+++ b/src/errors/csv/PlaceholderError.ts
@@ -1,0 +1,14 @@
+import { CsvValidationError } from "./CsvValidationError.js";
+
+export class PlaceholderError extends CsvValidationError {
+  constructor(
+    public columnName: string,
+    public column: number
+  ) {
+    super(
+      2,
+      column,
+      `Column header ${columnName} contains a placeholder. All placeholders must be removed from column headers.`
+    );
+  }
+}

--- a/src/errors/csv/index.ts
+++ b/src/errors/csv/index.ts
@@ -19,5 +19,6 @@ export * from "./MinRowsError.js";
 export * from "./ModifierMissingInfoError.js";
 export * from "./NotesRequiredError.js";
 export * from "./PercentageAlgorithmEstimateError.js";
+export * from "./PlaceholderError.js";
 export * from "./ProblemsInHeaderError.js";
 export * from "./RequiredValueError.js";

--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -1179,6 +1179,15 @@ export class CsvValidator extends BaseValidator {
     const errors: csvErr.CsvValidationError[] = [];
     if (semver.satisfies(this.version, ">=3.0.0")) {
       errors.push(...this.findPayersPlansPlaceholders(columns));
+      // because placeholders in payerPlans result in errors here,
+      // remove them from the list of payerPlans.
+      this.payersPlans = this.payersPlans.filter((payerPlan) => {
+        const splitPayerPlan = payerPlan.split(" | ");
+        return !(
+          matchesString(splitPayerPlan[0], "[payer_name]") ||
+          matchesString(splitPayerPlan[1], "[plan_name]")
+        );
+      });
     }
     this.dataColumns = [];
     this.normalizedColumns = [];
@@ -1459,8 +1468,8 @@ export class CsvValidator extends BaseValidator {
         if (
           matchesString(splitColumn[0], "standard_charge") &&
           chargePossibilities.some((p) => matchesString(p, splitColumn[3])) &&
-          matchesString(splitColumn[1], "[payer_name]") &&
-          matchesString(splitColumn[2], "[plan_name]")
+          (matchesString(splitColumn[1], "[payer_name]") ||
+            matchesString(splitColumn[2], "[plan_name]"))
         ) {
           errors.push(new csvErr.PlaceholderError(column, idx));
         }

--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -1176,13 +1176,20 @@ export class CsvValidator extends BaseValidator {
   validateColumns(columns: string[]): csvErr.CsvValidationError[] {
     this.isTall = this.areMyColumnsTall(columns);
     this.payersPlans = this.getPayersPlans(columns);
-    if (this.isTall === this.payersPlans.length > 0) {
-      return [new csvErr.AmbiguousFormatError()];
+    const errors: csvErr.CsvValidationError[] = [];
+    if (semver.satisfies(this.version, ">=3.0.0")) {
+      errors.push(...this.findPayersPlansPlaceholders(columns));
     }
     this.dataColumns = [];
     this.normalizedColumns = [];
-    const errors: csvErr.CsvValidationError[] = [];
     this.codeCount = this.getCodeCount(columns);
+    if (semver.satisfies(this.version, ">=3.0.0")) {
+      errors.push(...this.findCodePlaceholders(columns));
+    }
+
+    if (this.isTall === this.payersPlans.length > 0) {
+      return [...errors, new csvErr.AmbiguousFormatError()];
+    }
     const expectedDataColumns = CsvValidator.getExpectedDataColumns(
       this.version,
       this.codeCount,
@@ -1240,9 +1247,32 @@ export class CsvValidator extends BaseValidator {
             matchesString(c[0], "code") &&
             (c.length === 2 || (c.length === 3 && matchesString(c[2], "type")))
         )
-        .map((c) => +c[1].replace(/\D/g, ""))
+        .map((c) => {
+          return +c[1].replace(/\D/g, "");
+        })
         .filter((v) => !isNaN(v))
     );
+  }
+
+  findCodePlaceholders(columns: string[]): csvErr.PlaceholderError[] {
+    const errors: csvErr.PlaceholderError[] = [];
+    columns.map((c, idx) => {
+      const splitColumn = c
+        .split("|")
+        .map((v) => v.trim())
+        .filter((v) => !!v);
+      if (
+        (splitColumn.length === 2 && matchesString(splitColumn[0], "code")) ||
+        (splitColumn.length === 3 &&
+          matchesString(splitColumn[0], "code") &&
+          matchesString(splitColumn[2], "type"))
+      ) {
+        if (matchesString(splitColumn[1], "[i]")) {
+          errors.push(new csvErr.PlaceholderError(c, idx));
+        }
+      }
+    });
+    return errors;
   }
 
   static getExpectedDataColumns(
@@ -1413,6 +1443,45 @@ export class CsvValidator extends BaseValidator {
       }
     });
     return Array.from(payersPlans);
+  }
+
+  findPayersPlansPlaceholders(columns: string[]): csvErr.PlaceholderError[] {
+    const errors: csvErr.PlaceholderError[] = [];
+    columns.forEach((column, idx) => {
+      const splitColumn = column.split("|").map((p) => p.trim());
+      if (splitColumn.length === 4) {
+        const chargePossibilities = [
+          "negotiated_dollar",
+          "negotiated_percentage",
+          "negotiated_algorithm",
+          "methodology",
+        ];
+        if (
+          matchesString(splitColumn[0], "standard_charge") &&
+          chargePossibilities.some((p) => matchesString(p, splitColumn[3])) &&
+          matchesString(splitColumn[1], "[payer_name]") &&
+          matchesString(splitColumn[2], "[plan_name]")
+        ) {
+          errors.push(new csvErr.PlaceholderError(column, idx));
+        }
+      } else if (splitColumn.length === 3) {
+        const otherPossibilities = [
+          "additional_payer_notes",
+          "median_amount",
+          "10th_percentile",
+          "90th_percentile",
+          "count",
+        ];
+        if (
+          otherPossibilities.some((p) => matchesString(p, splitColumn[0])) &&
+          matchesString(splitColumn[1], "[payer_name]") &&
+          matchesString(splitColumn[2], "[plan_name]")
+        ) {
+          errors.push(new csvErr.PlaceholderError(column, idx));
+        }
+      }
+    });
+    return errors;
   }
 
   applyValidators(

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -11,6 +11,7 @@ import {
   PercentageAlgorithm90thError,
   PercentageAlgorithmCountError,
   PercentageAlgorithmMedianError,
+  PlaceholderError,
   RequiredValueError,
 } from "../../src/errors/csv/index.js";
 import { ATTESTATION } from "../../src/validators/CsvHelpers.js";
@@ -452,6 +453,140 @@ describe("CsvValidator v3.0.0", () => {
       );
       expect(result).toContainEqual(
         new ColumnMissingError("count | payer abc | plan 1")
+      );
+    });
+
+    it("should return an error when there is an unreplaced code placeholder", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "code | [i]",
+        "code | [i] | Type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "additional_generic_notes",
+      ]);
+      const result = validator.validateColumns(columns);
+      expect(result).toHaveLength(2);
+      expect(validator.isTall).toBe(false);
+      expect(validator.dataColumns).toEqual(columns);
+      expect(result).toContainEqual(
+        new PlaceholderError("code | [i]", columns.indexOf("code | [i]"))
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "code | [i] | Type",
+          columns.indexOf("code | [i] | Type")
+        )
+      );
+    });
+
+    it("should return an error when there is an unreplaced payer or plan placeholder", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "standard_charge | [payer_name] | [plan_name] | negotiated_dollar",
+        "standard_charge | [payer_name] | [plan_name] | negotiated_percentage",
+        "standard_charge | [payer_name] | [plan_name] | negotiated_algorithm",
+        "standard_charge | [payer_name] | [plan_name] | methodology",
+        "median_amount |  [payer_name] | [plan_name]",
+        "10th_percentile |  [payer_name] | [plan_name]",
+        "90th_percentile |  [payer_name] | [plan_name]",
+        "additional_payer_notes | [payer_name] | [plan_name]",
+        "count | [payer_name] | [plan_name]",
+        "additional_generic_notes",
+      ]);
+      const result = validator.validateColumns(columns);
+      expect(result).toHaveLength(9);
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "standard_charge | [payer_name] | [plan_name] | negotiated_dollar",
+          columns.indexOf(
+            "standard_charge | [payer_name] | [plan_name] | negotiated_dollar"
+          )
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "standard_charge | [payer_name] | [plan_name] | negotiated_percentage",
+          columns.indexOf(
+            "standard_charge | [payer_name] | [plan_name] | negotiated_percentage"
+          )
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "standard_charge | [payer_name] | [plan_name] | negotiated_algorithm",
+          columns.indexOf(
+            "standard_charge | [payer_name] | [plan_name] | negotiated_algorithm"
+          )
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "standard_charge | [payer_name] | [plan_name] | methodology",
+          columns.indexOf(
+            "standard_charge | [payer_name] | [plan_name] | methodology"
+          )
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "median_amount |  [payer_name] | [plan_name]",
+          columns.indexOf("median_amount |  [payer_name] | [plan_name]")
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "10th_percentile |  [payer_name] | [plan_name]",
+          columns.indexOf("10th_percentile |  [payer_name] | [plan_name]")
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "90th_percentile |  [payer_name] | [plan_name]",
+          columns.indexOf("90th_percentile |  [payer_name] | [plan_name]")
+        )
+      );
+      expect(result).toContainEqual(
+        new PlaceholderError(
+          "count | [payer_name] | [plan_name]",
+          columns.indexOf("count | [payer_name] | [plan_name]")
+        )
       );
     });
   });

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -589,6 +589,80 @@ describe("CsvValidator v3.0.0", () => {
         )
       );
     });
+
+    it("should return an error when there is an unreplaced payer name placeholder, and not return errors for related missing columns", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "standard_charge | [payer_name] | Plan 2 | negotiated_dollar",
+        "additional_generic_notes",
+      ]);
+      const result = validator.validateColumns(columns);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new PlaceholderError(
+          "standard_charge | [payer_name] | Plan 2 | negotiated_dollar",
+          columns.indexOf(
+            "standard_charge | [payer_name] | Plan 2 | negotiated_dollar"
+          )
+        )
+      );
+    });
+
+    it("should return an error when there is an unreplaced plan name placeholder, and not return errors for related missing columns", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "standard_charge | Plan XYZ | [plan_name] | negotiated_dollar",
+        "additional_generic_notes",
+      ]);
+      const result = validator.validateColumns(columns);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new PlaceholderError(
+          "standard_charge | Plan XYZ | [plan_name] | negotiated_dollar",
+          columns.indexOf(
+            "standard_charge | Plan XYZ | [plan_name] | negotiated_dollar"
+          )
+        )
+      );
+    });
   });
 
   describe("#validateDataRow tall", () => {


### PR DESCRIPTION
CSV headers definitions include placeholders: numbers for code and code type columns, and payer and plan names for CSV wide columns. Detect these placeholders when validating columns. When detected, return a PlaceholderError.

I decided to go with a simpler implementation that detected the placeholders in separate functions, rather than trying to integrate the placeholder detection into `getPayersPlans` and `getCodeCount`. The result is a little bit of repeated iteration, but it is a small cost compared to the overall validation process.