### PR TITLE
Add alerts for estimated amount in v3.0, nine 9s in allowed amount elements

### DIFF
--- a/src/alert-schemas/v3.0.0.json
+++ b/src/alert-schemas/v3.0.0.json
@@ -14,6 +14,29 @@
               "not": {
                 "required": ["estimated_amount"],
                 "$message": "Estimated amount present in payers information object."
+              },
+              "properties": {
+                "median_amount": {
+                  "type": "number",
+                  "not": {
+                    "const": 999999999,
+                    "$message": "Nine 9s used for median amount."
+                  }
+                },
+                "10th_percentile": {
+                  "type": "number",
+                  "not": {
+                    "const": 999999999,
+                    "$message": "Nine 9s used for 10th percentile."
+                  }
+                },
+                "90th_percentile": {
+                  "type": "number",
+                  "not": {
+                    "const": 999999999,
+                    "$message": "Nine 9s used for 90th percentile."
+                  }
+                }
               }
             }
           }

--- a/src/alert-schemas/v3.0.0.json
+++ b/src/alert-schemas/v3.0.0.json
@@ -16,6 +16,13 @@
                 "$message": "Estimated amount present in payers information object."
               },
               "properties": {
+                "count": {
+                  "type": "string",
+                  "not": {
+                    "const": "999999999",
+                    "$message": "Nine 9s used for count."
+                  }
+                },
                 "median_amount": {
                   "type": "number",
                   "not": {

--- a/src/alert-schemas/v3.0.0.json
+++ b/src/alert-schemas/v3.0.0.json
@@ -13,7 +13,7 @@
               "type": "object",
               "not": {
                 "required": ["estimated_amount"],
-                "$message": "Estimated amount present in payers information object."
+                "$message": "The 'estimated amount' is no longer a required data element as of January 1, 2026. It has been replaced by the 10th percentile, median, 90th percentile, and count of allowed amounts."
               },
               "properties": {
                 "count": {

--- a/src/alert-schemas/v3.0.0.json
+++ b/src/alert-schemas/v3.0.0.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "standard_charges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "payers_information": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "not": {
+                "required": ["estimated_amount"],
+                "$message": "Estimated amount present in payers information object."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/alerts/CsvNineNinesAlert.ts
+++ b/src/alerts/CsvNineNinesAlert.ts
@@ -1,7 +1,7 @@
 import { CsvValidationError } from "../errors/csv/index.js";
 
 export class CsvNineNinesAlert extends CsvValidationError {
-  constructor(row: number, column: number) {
-    super(row, column, "Nine 9s used for estimated amount.");
+  constructor(row: number, column: number, columnName: string) {
+    super(row, column, `Nine 9s used for ${columnName}.`);
   }
 }

--- a/src/alerts/EstimatedAmountAlert.ts
+++ b/src/alerts/EstimatedAmountAlert.ts
@@ -1,0 +1,7 @@
+import { CsvValidationError } from "../errors/csv/index.js";
+
+export class EstimatedAmountAlert extends CsvValidationError {
+  constructor(column: number, columnName: string) {
+    super(2, column, `Column ${columnName} found in column headers.`);
+  }
+}

--- a/src/alerts/EstimatedAmountAlert.ts
+++ b/src/alerts/EstimatedAmountAlert.ts
@@ -2,6 +2,10 @@ import { CsvValidationError } from "../errors/csv/index.js";
 
 export class EstimatedAmountAlert extends CsvValidationError {
   constructor(column: number, columnName: string) {
-    super(2, column, `Column ${columnName} found in column headers.`);
+    super(
+      2,
+      column,
+      `Column ${columnName} found in column headers. The 'estimated amount' is no longer a required data element as of January 1, 2026. It has been replaced by the 10th percentile, median, 90th percentile, and count of allowed amounts.`
+    );
   }
 }

--- a/src/alerts/index.ts
+++ b/src/alerts/index.ts
@@ -1,1 +1,3 @@
 export * from "./CsvNineNinesAlert.js";
+export * from "./EstimatedAmountAlert.js";
+export * from "./FalseStatementAlert.js";

--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -793,6 +793,7 @@ export class CsvValidator extends BaseValidator {
           applicableVersion: ">=3.0.0",
           validator: (dataRow, row) => {
             return [
+              { field: "count", friendly: "count" },
               { field: "median_amount", friendly: "median amount" },
               { field: "10th_percentile", friendly: "10th percentile" },
               { field: "90th_percentile", friendly: "90th percentile" },
@@ -998,6 +999,10 @@ export class CsvValidator extends BaseValidator {
             applicableVersion: ">=3.0.0",
             validator: (dataRow, row) => {
               return [
+                {
+                  field: `count | ${payerPlan}`,
+                  friendly: "count",
+                },
                 {
                   field: `median_amount | ${payerPlan}`,
                   friendly: "median amount",

--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -4,7 +4,7 @@ import { CsvValidationOptions, ValidationResult } from "../types.js";
 import { BaseValidator } from "./BaseValidator.js";
 import { addItemsWithLimit, removeBOM } from "../utils.js";
 import * as csvErr from "../errors/csv/index.js";
-import { CsvNineNinesAlert } from "../alerts/index.js";
+import { CsvNineNinesAlert, EstimatedAmountAlert } from "../alerts/index.js";
 import _ from "lodash";
 const { range, partial, bind } = _;
 import { BranchingValidator, CsvFileLevelValidator } from "./CsvFieldTypes.js";
@@ -1240,6 +1240,41 @@ export class CsvValidator extends BaseValidator {
     return errors;
   }
 
+  alertColumns(columns: string[]): csvErr.CsvValidationError[] {
+    const alerts: csvErr.CsvValidationError[] = [];
+    // currently, the only alert applies starting at v3.0.0
+    if (semver.satisfies(this.version, ">=3.0.0")) {
+      if (this.isTall) {
+        const estimatedAmountIndex = columns.findIndex((col) =>
+          matchesString(col, "estimated_amount")
+        );
+        if (estimatedAmountIndex > -1) {
+          alerts.push(
+            new EstimatedAmountAlert(
+              estimatedAmountIndex,
+              columns[estimatedAmountIndex]
+            )
+          );
+        }
+      } else {
+        this.payersPlans.forEach((payerPlan) => {
+          const estimatedAmountIndex = columns.findIndex((col) =>
+            sepColumnsEqual(col, `estimated_amount | ${payerPlan}`)
+          );
+          if (estimatedAmountIndex > -1) {
+            alerts.push(
+              new EstimatedAmountAlert(
+                estimatedAmountIndex,
+                columns[estimatedAmountIndex]
+              )
+            );
+          }
+        });
+      }
+    }
+    return alerts;
+  }
+
   getCodeCount(columns: string[]): number {
     return Math.max(
       0,
@@ -1589,6 +1624,7 @@ export class CsvValidator extends BaseValidator {
         });
         parser.abort();
       } else {
+        addItemsWithLimit(this.alertColumns(row), this.alerts, this.maxErrors);
         this.buildRowValidators();
         this.buildFileValidators();
       }

--- a/src/validators/CsvValidator.ts
+++ b/src/validators/CsvValidator.ts
@@ -767,24 +767,51 @@ export class CsvValidator extends BaseValidator {
           return [];
         },
       });
-
-      // amount data element within the MRF and should instead encode an actual dollar amount. // Hospitals should discontinue encoding 999999999 (nine 9s) in the estimated allowed
+      // Hospitals should discontinue encoding 999999999 (nine 9s) in the estimated allowed
+      // amount data element within the MRF and should instead encode an actual dollar amount.
       // new as of 2025/05/22, at which point v2.2.0 was in effect.
-      this.rowAlerters.push({
-        name: "discontinue encoding nine 9s for estimated amount",
-        applicableVersion: ">=2.2.0",
-        validator: (dataRow, row) => {
-          if (Number(dataRow.estimated_amount) === 999999999) {
-            return [
-              new CsvNineNinesAlert(
-                row,
-                this.normalizedColumns.indexOf("estimated_amount")
-              ),
-            ];
-          }
-          return [];
+      // additionally, hospitals should not encode nine 9s for any of the v3 allowed amount elements.
+      this.rowAlerters.push(
+        {
+          name: "discontinue encoding nine 9s for estimated amount",
+          applicableVersion: ">=2.2.0",
+          validator: (dataRow, row) => {
+            if (Number(dataRow.estimated_amount) === 999999999) {
+              return [
+                new CsvNineNinesAlert(
+                  row,
+                  this.normalizedColumns.indexOf("estimated_amount"),
+                  "estimated amount"
+                ),
+              ];
+            }
+            return [];
+          },
         },
-      });
+        {
+          name: "do not encode nine 9s for allowed amounts",
+          applicableVersion: ">=3.0.0",
+          validator: (dataRow, row) => {
+            return [
+              { field: "median_amount", friendly: "median amount" },
+              { field: "10th_percentile", friendly: "10th percentile" },
+              { field: "90th_percentile", friendly: "90th percentile" },
+            ]
+              .filter(
+                (allowedField) =>
+                  Number(dataRow[allowedField.field]) === 999999999
+              )
+              .map(
+                (allowedField) =>
+                  new CsvNineNinesAlert(
+                    row,
+                    this.normalizedColumns.indexOf(allowedField.field),
+                    allowedField.friendly
+                  )
+              );
+          },
+        }
+      );
     } else {
       // some checks diverge based on whether this is a modifier row
       // If a modifier is encoded without an item or service, then a description and one of the following
@@ -945,25 +972,60 @@ export class CsvValidator extends BaseValidator {
         // Hospitals should discontinue encoding 999999999 (nine 9s) in the estimated allowed
         // amount data element within the MRF and should instead encode an actual dollar amount.
         // new as of 2025/05/22, at which point v2.2.0 was in effect.
-        this.rowAlerters.push({
-          name: "discontinue encoding nine 9s for estimated amount",
-          applicableVersion: ">=2.2.0",
-          validator: (dataRow, row) => {
-            if (
-              Number(dataRow[`estimated_amount | ${payerPlan}`]) === 999999999
-            ) {
-              return [
-                new CsvNineNinesAlert(
-                  row,
-                  this.normalizedColumns.indexOf(
-                    `estimated_amount | ${payerPlan}`
-                  )
-                ),
-              ];
-            }
-            return [];
+        this.rowAlerters.push(
+          {
+            name: "discontinue encoding nine 9s for estimated amount",
+            applicableVersion: ">=2.2.0",
+            validator: (dataRow, row) => {
+              if (
+                Number(dataRow[`estimated_amount | ${payerPlan}`]) === 999999999
+              ) {
+                return [
+                  new CsvNineNinesAlert(
+                    row,
+                    this.normalizedColumns.indexOf(
+                      `estimated_amount | ${payerPlan}`
+                    ),
+                    "estimated amount"
+                  ),
+                ];
+              }
+              return [];
+            },
           },
-        });
+          {
+            name: "do not encode nine 9s for allowed amounts",
+            applicableVersion: ">=3.0.0",
+            validator: (dataRow, row) => {
+              return [
+                {
+                  field: `median_amount | ${payerPlan}`,
+                  friendly: "median amount",
+                },
+                {
+                  field: `10th_percentile | ${payerPlan}`,
+                  friendly: "10th percentile",
+                },
+                {
+                  field: `90th_percentile | ${payerPlan}`,
+                  friendly: "90th percentile",
+                },
+              ]
+                .filter(
+                  (allowedField) =>
+                    Number(dataRow[allowedField.field]) === 999999999
+                )
+                .map(
+                  (allowedField) =>
+                    new CsvNineNinesAlert(
+                      row,
+                      this.normalizedColumns.indexOf(allowedField.field),
+                      allowedField.friendly
+                    )
+                );
+            },
+          }
+        );
       });
     }
 

--- a/src/validators/JsonValidator.ts
+++ b/src/validators/JsonValidator.ts
@@ -20,6 +20,7 @@ import v210schema from "../schemas/v2.1.0.json" with { type: "json" };
 import v220schema from "../schemas/v2.2.0.json" with { type: "json" };
 import v300schema from "../schemas/v3.0.0.json" with { type: "json" };
 import v220alerts from "../alert-schemas/v2.2.0.json" with { type: "json" };
+import v300alerts from "../alert-schemas/v3.0.0.json" with { type: "json" };
 import semver from "semver";
 import { JsonFileLevelValidator } from "./JsonFileLevelValidator.js";
 import {
@@ -59,6 +60,7 @@ export class JsonValidator extends BaseValidator {
           break;
         case "3.0.0":
           this.fullSchema = v300schema;
+          this.alertSchema = v300alerts;
           break;
         default:
           throw new Error("unrecognized version");

--- a/test/fixtures/3.0/allowed-amounts-nine-9s.json
+++ b/test/fixtures/3.0/allowed-amounts-nine-9s.json
@@ -1,0 +1,212 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "location_name": ["West Mercy Hospital", "West Mercy Surgical Center"],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "type_2_npi": ["1122334455", "6677889900"],
+  "attestation": {
+    "attestation": "To the best of its knowledge and belief, this hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date in the file. This hospital has included all payer-specific negotiated charges in dollars that can be expressed as a dollar amount. For payer-specific negotiated charges that cannot be expressed as a dollar amount in the machine-readable file or not knowable in advance, the hospital attests that the payer-specific negotiated charge is based on a contractual algorithm, percentage or formula that precludes the provision of a dollar amount and has provided all necessary information available to the hospital for the public to be able to derive the dollar amount, including, but not limited to, the specific fee schedule or components referenced in such percentage, algorithm or formula.",
+    "attester_name": "Malcom Attester",
+    "confirm_attestation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "CMG"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "123",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "median_amount": 22243.34,
+              "10th_percentile": 999999999,
+              "90th_percentile": 25440.9,
+              "count": "234",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "1 through 10",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 999999999,
+              "count": "456",
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "median_amount": 999999999,
+              "10th_percentile": 85.08,
+              "90th_percentile": 115.9,
+              "count": "567",
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/3.0/allowed-amounts-nine-9s.json
+++ b/test/fixtures/3.0/allowed-amounts-nine-9s.json
@@ -44,7 +44,7 @@
               "median_amount": 22243.34,
               "10th_percentile": 18500.08,
               "90th_percentile": 25440.9,
-              "count": "123",
+              "count": "999999999",
               "methodology": "case rate"
             },
             {

--- a/test/fixtures/3.0/estimated-amount.json
+++ b/test/fixtures/3.0/estimated-amount.json
@@ -1,0 +1,213 @@
+{
+  "hospital_name": "West Mercy Hospital",
+  "last_updated_on": "2024-07-01",
+  "version": "2.0.0",
+  "location_name": ["West Mercy Hospital", "West Mercy Surgical Center"],
+  "hospital_address": [
+    "12 Main Street, Fullerton, CA  92832",
+    "23 Ocean Ave, San Jose, CA 94088"
+  ],
+  "license_information": {
+    "license_number": "50056",
+    "state": "CA"
+  },
+  "type_2_npi": ["1122334455", "6677889900"],
+  "attestation": {
+    "attestation": "To the best of its knowledge and belief, this hospital has included all applicable standard charge information in accordance with the requirements of 45 CFR 180.50, and the information encoded is true, accurate, and complete as of the date in the file. This hospital has included all payer-specific negotiated charges in dollars that can be expressed as a dollar amount. For payer-specific negotiated charges that cannot be expressed as a dollar amount in the machine-readable file or not knowable in advance, the hospital attests that the payer-specific negotiated charge is based on a contractual algorithm, percentage or formula that precludes the provision of a dollar amount and has provided all necessary information available to the hospital for the public to be able to derive the dollar amount, including, but not limited to, the specific fee schedule or components referenced in such percentage, algorithm or formula.",
+    "attester_name": "Malcom Attester",
+    "confirm_attestation": true
+  },
+  "standard_charge_information": [
+    {
+      "description": "Major hip and knee joint replacement or reattachment of lower extremity without mcc",
+      "code_information": [
+        {
+          "code": "470",
+          "type": "MS-DRG"
+        },
+        {
+          "code": "175869",
+          "type": "CMG"
+        }
+      ],
+      "standard_charges": [
+        {
+          "minimum": 20000,
+          "maximum": 20000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "MS-DRG",
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "123",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/html/images/OP.jpg",
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "234",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 20000,
+              "standard_charge_algorithm": "The adjusted base payment rate indicated in the standard_charge|negotiated_dollar data element may be further adjusted for additional factors including transfers and outliers.",
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "1 through 10",
+              "methodology": "case rate"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 50,
+              "median_amount": 22243.34,
+              "10th_percentile": 18500.08,
+              "90th_percentile": 25440.9,
+              "count": "456",
+              "estimated_amount": 23000,
+              "methodology": "percent of total billed charges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Evaluation of hearing function to determine candidacy for, or postoperative status of, surgically implanted hearing device; first hour",
+      "code_information": [
+        {
+          "code": "92626",
+          "type": "CPT"
+        }
+      ],
+      "standard_charges": [
+        {
+          "setting": "outpatient",
+          "gross_charge": 150,
+          "discounted_cash": 125,
+          "minimum": 98.98,
+          "maximum": 98.98,
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 98.98,
+              "methodology": "fee schedule",
+              "additional_payer_notes": "110% of the Medicare fee schedule"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_percentage": 115,
+              "median_amount": 105.34,
+              "10th_percentile": 85.08,
+              "90th_percentile": 115.9,
+              "count": "567",
+              "methodology": "fee schedule",
+              "additional_payer_notes": "115% of the state's workers' compensation amount"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Behavioral health; residential (hospital residential treatment program), without room and board, per diem",
+      "code_information": [
+        {
+          "code": "H0017",
+          "type": "HCPCS"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 2500,
+          "discounted_cash": 2250,
+          "minimum": 1200,
+          "maximum": 2000,
+          "setting": "inpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 1500,
+              "methodology": "per diem"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 2000,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 1-3"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1800,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 4-5"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 1200,
+              "methodology": "per diem",
+              "additional_payer_notes": "per diem, days 6+"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Treatment or observation room — observation room",
+      "code_information": [
+        {
+          "code": "762",
+          "type": "RC"
+        }
+      ],
+      "standard_charges": [
+        {
+          "gross_charge": 13000,
+          "discounted_cash": 12000,
+          "minimum": 8000,
+          "maximum": 10000,
+          "setting": "outpatient",
+          "payers_information": [
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 8000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and without rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Platform Health Insurance",
+              "plan_name": "PPO",
+              "standard_charge_dollar": 10000,
+              "methodology": "case rate",
+              "additional_payer_notes": "Negotiated standard charge without surgery and with rule out myocardial infarction"
+            },
+            {
+              "payer_name": "Region Health Insurance",
+              "plan_name": "HMO",
+              "standard_charge_dollar": 9000,
+              "methodology": "case rate"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/validators/CsvValidator.v2.2.0.test.ts
+++ b/test/validators/CsvValidator.v2.2.0.test.ts
@@ -1441,7 +1441,9 @@ describe("CsvValidator v2.2.0", () => {
       row.estimated_amount = "999999999";
       const result = validator.alertDataRow(row);
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(new CsvNineNinesAlert(validator.index, 20));
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 20, "estimated amount")
+      );
     });
   });
 
@@ -1928,7 +1930,9 @@ describe("CsvValidator v2.2.0", () => {
       row["estimated_amount | payer abc | plan 1"] = "999999999";
       const result = validator.alertDataRow(row);
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(new CsvNineNinesAlert(validator.index, 17));
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 17, "estimated amount")
+      );
     });
   });
 });

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -17,6 +17,7 @@ import {
 import { ATTESTATION } from "../../src/validators/CsvHelpers.js";
 import {
   CsvFalseAttestationAlert,
+  CsvNineNinesAlert,
   EstimatedAmountAlert,
 } from "../../src/alerts/index.js";
 
@@ -1112,6 +1113,54 @@ describe("CsvValidator v3.0.0", () => {
         new ChargeWithPayerPlanError(validator.index, 14)
       );
     });
+
+    it("should return an alert when 999999999 is encoded for 10th percentile", () => {
+      row.payer_name = "Payer Three";
+      row.plan_name = "Plan W";
+      row["standard_charge | negotiated_percentage"] = "85";
+      row["standard_charge | methodology"] = "fee schedule";
+      row.count = "1 through 10";
+      row.median_amount = "370";
+      row["10th_percentile"] = "999999999";
+      row["90th_percentile"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 21, "10th percentile")
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for median amount", () => {
+      row.payer_name = "Payer Three";
+      row.plan_name = "Plan W";
+      row["standard_charge | negotiated_percentage"] = "85";
+      row["standard_charge | methodology"] = "fee schedule";
+      row.count = "1 through 10";
+      row.median_amount = "999999999";
+      row["10th_percentile"] = "250";
+      row["90th_percentile"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 20, "median amount")
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for 90th percentile", () => {
+      row.payer_name = "Payer Three";
+      row.plan_name = "Plan W";
+      row["standard_charge | negotiated_percentage"] = "85";
+      row["standard_charge | methodology"] = "fee schedule";
+      row.count = "1 through 10";
+      row.median_amount = "370";
+      row["10th_percentile"] = "20";
+      row["90th_percentile"] = "999999999";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 22, "90th percentile")
+      );
+    });
   });
 
   describe("#validateDataRow wide", () => {
@@ -1406,6 +1455,66 @@ describe("CsvValidator v3.0.0", () => {
         new PercentageAlgorithm90thError(
           validator.index,
           normalizedColumns.indexOf("90th_percentile | payer xyz | plan 2")
+        )
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for 10th percentile", () => {
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
+        "85";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
+        "fee schedule";
+      row["count | payer abc | plan 1"] = "35";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["10th_percentile | payer abc | plan 1"] = "999999999";
+      row["90th_percentile | payer abc | plan 1"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(
+          validator.index,
+          normalizedColumns.indexOf("10th_percentile | payer abc | plan 1"),
+          "10th percentile"
+        )
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for median amount", () => {
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
+        "85";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
+        "fee schedule";
+      row["count | payer abc | plan 1"] = "35";
+      row["median_amount | payer abc | plan 1"] = "999999999";
+      row["10th_percentile | payer abc | plan 1"] = "250";
+      row["90th_percentile | payer abc | plan 1"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(
+          validator.index,
+          normalizedColumns.indexOf("median_amount | payer abc | plan 1"),
+          "median amount"
+        )
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for 90th percentile", () => {
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
+        "85";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
+        "fee schedule";
+      row["count | payer abc | plan 1"] = "35";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["10th_percentile | payer abc | plan 1"] = "250";
+      row["90th_percentile | payer abc | plan 1"] = "999999999";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(
+          validator.index,
+          normalizedColumns.indexOf("90th_percentile | payer abc | plan 1"),
+          "90th percentile"
         )
       );
     });

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -1114,6 +1114,22 @@ describe("CsvValidator v3.0.0", () => {
       );
     });
 
+    it("should return an alert when 999999999 is encoded for count", () => {
+      row.payer_name = "Payer Three";
+      row.plan_name = "Plan W";
+      row["standard_charge | negotiated_percentage"] = "85";
+      row["standard_charge | methodology"] = "fee schedule";
+      row.count = "999999999";
+      row.median_amount = "370";
+      row["10th_percentile"] = "250";
+      row["90th_percentile"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(validator.index, 23, "count")
+      );
+    });
+
     it("should return an alert when 999999999 is encoded for 10th percentile", () => {
       row.payer_name = "Payer Three";
       row.plan_name = "Plan W";
@@ -1455,6 +1471,26 @@ describe("CsvValidator v3.0.0", () => {
         new PercentageAlgorithm90thError(
           validator.index,
           normalizedColumns.indexOf("90th_percentile | payer xyz | plan 2")
+        )
+      );
+    });
+
+    it("should return an alert when 999999999 is encoded for count", () => {
+      row["standard_charge | payer abc | plan 1 | negotiated_percentage"] =
+        "85";
+      row["standard_charge | payer abc | plan 1 | methodology"] =
+        "fee schedule";
+      row["count | payer abc | plan 1"] = "999999999";
+      row["median_amount | payer abc | plan 1"] = "370";
+      row["10th_percentile | payer abc | plan 1"] = "250";
+      row["90th_percentile | payer abc | plan 1"] = "505";
+      const result = validator.alertDataRow(row);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        new CsvNineNinesAlert(
+          validator.index,
+          normalizedColumns.indexOf("count | payer abc | plan 1"),
+          "count"
         )
       );
     });

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -15,7 +15,10 @@ import {
   RequiredValueError,
 } from "../../src/errors/csv/index.js";
 import { ATTESTATION } from "../../src/validators/CsvHelpers.js";
-import { CsvFalseAttestationAlert } from "../../src/alerts/FalseStatementAlert.js";
+import {
+  CsvFalseAttestationAlert,
+  EstimatedAmountAlert,
+} from "../../src/alerts/index.js";
 
 const { shuffle } = _;
 
@@ -660,6 +663,148 @@ describe("CsvValidator v3.0.0", () => {
           columns.indexOf(
             "standard_charge | Plan XYZ | [plan_name] | negotiated_dollar"
           )
+        )
+      );
+    });
+  });
+
+  describe("#alertColumns", () => {
+    it("should return no alerts when expected tall columns are provided", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge   | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "additional_generic_notes",
+        "payer_name",
+        "plan_name",
+        "standard_charge | negotiated_dollar",
+        "standard_charge | negotiated_percentage",
+        "standard_charge | negotiated_algorithm",
+        "standard_charge | methodology",
+        "median_amount",
+        "10th_percentile",
+        "90th_percentile",
+        "count",
+      ]);
+
+      const errors = validator.validateColumns(columns);
+      expect(errors).toHaveLength(0);
+      const alerts = validator.alertColumns(columns);
+      expect(alerts).toHaveLength(0);
+    });
+
+    it("should return an alert when an estimated_amount column is provided", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge   | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "additional_generic_notes",
+        "payer_name",
+        "plan_name",
+        "standard_charge | negotiated_dollar",
+        "standard_charge | negotiated_percentage",
+        "standard_charge | negotiated_algorithm",
+        "standard_charge | methodology",
+        "estimated_amount", // this column was removed, so we alert when it appears
+        "median_amount",
+        "10th_percentile",
+        "90th_percentile",
+        "count",
+      ]);
+
+      const errors = validator.validateColumns(columns);
+      expect(errors).toHaveLength(0);
+      const alerts = validator.alertColumns(columns);
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0]).toEqual(
+        new EstimatedAmountAlert(
+          columns.indexOf("estimated_amount"),
+          "estimated_amount"
+        )
+      );
+    });
+
+    it("should return no alerts when expected wide columns are provided", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "additional_generic_notes",
+      ]);
+
+      const errors = validator.validateColumns(columns);
+      expect(errors).toHaveLength(0);
+      const alerts = validator.alertColumns(columns);
+      expect(alerts).toHaveLength(0);
+    });
+
+    it("should return an alert when a payer-specific estimated_amount column is provided", () => {
+      const columns = shuffle([
+        "description",
+        "code | 1",
+        "code | 1 | type",
+        "setting",
+        "drug_unit_of_measurement",
+        "drug_type_of_measurement",
+        "modifiers",
+        "standard_charge | gross",
+        "standard_charge | discounted_cash",
+        "standard_charge | min",
+        "standard_charge | max",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_dollar",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_percentage",
+        "standard_charge | Payer ABC | Plan 1 | negotiated_algorithm",
+        "standard_charge | Payer ABC | Plan 1 | methodology",
+        "estimated_amount | Payer ABC | Plan 1",
+        "median_amount |  Payer ABC | Plan 1",
+        "10th_percentile |  Payer ABC | Plan 1",
+        "90th_percentile |  Payer ABC | Plan 1",
+        "additional_payer_notes | Payer ABC | Plan 1",
+        "count | Payer ABC | Plan 1",
+        "additional_generic_notes",
+      ]);
+
+      const errors = validator.validateColumns(columns);
+      expect(errors).toHaveLength(0);
+      const alerts = validator.alertColumns(columns);
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0]).toEqual(
+        new EstimatedAmountAlert(
+          columns.indexOf("estimated_amount | Payer ABC | Plan 1"),
+          "estimated_amount | Payer ABC | Plan 1"
         )
       );
     });

--- a/test/validators/JsonValidator.test.ts
+++ b/test/validators/JsonValidator.test.ts
@@ -660,7 +660,8 @@ describe("JsonValidator", () => {
       expect(result.alerts).toHaveLength(1);
       expect(result.alerts).toContainEqual<ValidationError>(
         expect.objectContaining({
-          message: "Estimated amount present in payers information object.",
+          message:
+            "The 'estimated amount' is no longer a required data element as of January 1, 2026. It has been replaced by the 10th percentile, median, 90th percentile, and count of allowed amounts.",
           path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
         })
       );

--- a/test/validators/JsonValidator.test.ts
+++ b/test/validators/JsonValidator.test.ts
@@ -665,5 +665,33 @@ describe("JsonValidator", () => {
         })
       );
     });
+
+    it("should validate a file that uses nine 9s for allowed amounts", async () => {
+      const input = createFixtureStream(
+        path.join("3.0", "allowed-amounts-nine-9s.json")
+      );
+      const result = await validator.validate(input);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.alerts).toHaveLength(3);
+      expect(result.alerts).toContainEqual<ValidationError>(
+        expect.objectContaining({
+          message: "Nine 9s used for median amount.",
+          path: "/standard_charge_information/1/standard_charges/0/payers_information/1/median_amount",
+        })
+      );
+      expect(result.alerts).toContainEqual<ValidationError>(
+        expect.objectContaining({
+          message: "Nine 9s used for 10th percentile.",
+          path: "/standard_charge_information/0/standard_charges/0/payers_information/1/10th_percentile",
+        })
+      );
+      expect(result.alerts).toContainEqual<ValidationError>(
+        expect.objectContaining({
+          message: "Nine 9s used for 90th percentile.",
+          path: "/standard_charge_information/0/standard_charges/0/payers_information/3/90th_percentile",
+        })
+      );
+    });
   });
 });

--- a/test/validators/JsonValidator.test.ts
+++ b/test/validators/JsonValidator.test.ts
@@ -673,7 +673,13 @@ describe("JsonValidator", () => {
       const result = await validator.validate(input);
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
-      expect(result.alerts).toHaveLength(3);
+      expect(result.alerts).toHaveLength(4);
+      expect(result.alerts).toContainEqual<ValidationError>(
+        expect.objectContaining({
+          message: "Nine 9s used for count.",
+          path: "/standard_charge_information/0/standard_charges/0/payers_information/0/count",
+        })
+      );
       expect(result.alerts).toContainEqual<ValidationError>(
         expect.objectContaining({
           message: "Nine 9s used for median amount.",

--- a/test/validators/JsonValidator.test.ts
+++ b/test/validators/JsonValidator.test.ts
@@ -649,5 +649,21 @@ describe("JsonValidator", () => {
         new JsonFalseAttestationAlert()
       );
     });
+
+    it("should validate a file that contains an estimated_amount element", async () => {
+      const input = createFixtureStream(
+        path.join("3.0", "estimated-amount.json")
+      );
+      const result = await validator.validate(input);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts).toContainEqual<ValidationError>(
+        expect.objectContaining({
+          message: "Estimated amount present in payers information object.",
+          path: "/standard_charge_information/0/standard_charges/0/payers_information/3",
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
The estimated amount property was removed from the data dictionaries in version 3.0. If validating a file with version 3.0 or later, show an alert if a CSV column header is found that would match that property's definition, and show an alert if a payers information object in JSON contains an estimated amount property. Do not show these alerts for versions prior to 3.0.

Emit an alert when validating a file on version 3.0.0 or later and a value of nine 9s is encoded for count, median amount, 10th percentile, or 90th percentile.