### PR TITLE
CSV: Add MS-LTC-DRG to list of code types for v3

### DIFF
--- a/src/validators/CsvHelpers.ts
+++ b/src/validators/CsvHelpers.ts
@@ -335,7 +335,7 @@ export function dynaValidateRequiredField(
 export function getBillingCodesByVersion(version: string): string[] {
   const extraCodes: string[] = [];
   if (semver.satisfies(version, ">=3.0.0")) {
-    extraCodes.push("CMG");
+    extraCodes.push("CMG", "MS-LTC-DRG");
   }
   return [...BILLING_CODE_TYPES, ...extraCodes];
 }

--- a/test/validators/CsvValidator.v3.0.0.test.ts
+++ b/test/validators/CsvValidator.v3.0.0.test.ts
@@ -933,6 +933,13 @@ describe("CsvValidator v3.0.0", () => {
       expect(result).toHaveLength(0);
     });
 
+    // MS-LTC-DRG is a new allowed value for code type
+    it("should return no errors when a MS-LTC-DRG code is used", () => {
+      row["code | 1 | type"] = "MS-LTC-DRG";
+      const result = validator.validateDataRow(row);
+      expect(result).toHaveLength(0);
+    });
+
     // count of allowed amounts, median, 10th percentile, and 90th percentile are new numeric fields
     // count of allowed amounts, unlike other numeric fields, may have a value of 0
     it("should return an error when count of allowed amounts is present, but not 0 or a postive number", () => {


### PR DESCRIPTION
This code type is present in the JSON schema for v3.0, but wasn't in the list of extra allowed values for CSV.